### PR TITLE
Add token app to manage user tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,91 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Webapp Docker Attach",
-            "type": "python",
-            "request": "attach",
-            "connect": {
-                "host": "127.0.0.1",
-                "port": 5679
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "/autoreduce-frontend"
-                }
-            ],
-            "presentation": {
-                "hidden": false,
-                "group": "autoreduce-frontend-docker",
-                "order": 1
-            },
-            "preLaunchTask": "(don't use directly) Exec runserver",
-            "django": true
-        },
-        {
-            "name": "pytest django Docker Attach",
-            "type": "python",
-            "request": "attach",
-            "connect": {
-                "host": "127.0.0.1",
-                "port": 5681
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "/autoreduce-frontend"
-                }
-            ],
-            "presentation": {
-                "hidden": false,
-                "group": "autoreduce-frontend-docker",
-                "order": 1
-            },
-            "preLaunchTask": "(don't use directly) Exec pytest django",
-        },
-        {
-            "name": "Pytest",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "args": [
-                "-v",
-                "${file}"
-            ],
-            "django": true,
-            "presentation": {
-                "hidden": false,
-                "group": "autoreduce-frontend",
-            },
-            "env": {
-                "DISPLAY": ":1",
-                "RUNNING_VIA_PYTEST": "true",
-                "SELENIUM_REMOTE": "1"
-            }
-        },
-        {
-            "name": "Pytest - coverage",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "args": [
-                "--cov-report",
-                "html",
-                "--cov=${workspaceFolder}/queue_processors",
-                "-pno:django",
-                "-v",
-                "${file}"
-            ],
-            "presentation": {
-                "hidden": false,
-                "group": "autoreduce-frontend",
-            },
-            "env": {
-                "RUNNING_VIA_PYTEST": "true"
-            }
-        },
-        {
-            "name": "Web app",
+            "name": "Run Autoreduce webapp",
             "type": "python",
             "request": "launch",
             "cwd": "${workspaceFolder}",
@@ -100,28 +16,13 @@
             "django": true,
             "presentation": {
                 "hidden": false,
-                "group": "autoreduce-frontend",
-                "order": 99
+                "group": "autoreduce-run",
+                "order": 1
             },
             "env": {
                 "PYTHONPATH": "${workspaceFolder}"
             },
             "justMyCode": false
-        },
-        {
-            "name": "Attach",
-            "type": "python",
-            "request": "attach",
-            "connect": {
-                "host": "127.0.0.1",
-                "port": 5678
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "/autoreduce"
-                }
-            ]
         },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,28 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Pytest",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "-v",
+                "${file}"
+            ],
+            "django": true,
+            "presentation": {
+                "hidden": false,
+                "group": "autoreduce-test",
+            },
+            "env": {
+                "DISPLAY": ":1",
+                "RUNNING_VIA_PYTEST": "true",
+                "SELENIUM_REMOTE": "1"
+            },
+            "justMyCode": false
+        },
+        {
             "name": "Run webapp",
             "type": "python",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,28 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Pytest",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "cwd": "${workspaceFolder}",
-            "args": [
-                "-v",
-                "${file}"
-            ],
-            "django": true,
-            "presentation": {
-                "hidden": false,
-                "group": "autoreduce-test",
-            },
-            "env": {
-                "DISPLAY": ":1",
-                "RUNNING_VIA_PYTEST": "true",
-                "SELENIUM_REMOTE": "1"
-            },
-            "justMyCode": false
-        },
-        {
             "name": "Run webapp",
             "type": "python",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run Autoreduce webapp",
+            "name": "Run webapp",
             "type": "python",
             "request": "launch",
             "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,21 +21,21 @@
         {
             "label": "Migrate credentials",
             "type": "shell",
-            "command": "autoreduce-creds-migrate",
+            "command": "make credentials",
             "problemMatcher": [],
             "group": "build"
         },
         {
             "label": "Migrate database (with PR fixtures)",
             "type": "shell",
-            "command": "python ${workspaceFolder}/autoreduce_frontend/manage.py migrate && python ${workspaceFolder}/autoreduce_frontend/manage.py loaddata super_user_fixture status_fixture pr_test'",
+            "command": "make migrate-with-fixtures",
             "problemMatcher": [],
             "group": "build"
         },
         {
             "label": "Migrate database (clean)",
             "type": "shell",
-            "command": "python ${workspaceFolder}/autoreduce_frontend/manage.py migrate",
+            "command": "make migrate",
             "isBackground": true,
             "problemMatcher": [],
             "group": "build"
@@ -43,7 +43,7 @@
         {
             "label": "Run Selenium Docker daemon",
             "type": "shell",
-            "command": "docker run --network host --name selenium --rm -it -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-3-prerelease-20210422",
+            "command": "make selenium",
             "problemMatcher": []
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,134 +4,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Make ~/.autoreduce/dev/reduced-data",
-            "type": "shell",
-            "command": "mkdir -p ~/.autoreduce/dev/reduced-data",
-            "problemMatcher": [],
-            "presentation": {
-                "echo": false,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            }
-        },
-        {
-            "label": "Export UID:GID to $USERID",
-            "type": "shell",
-            "command": "echo 'export USERID=$(id -u):$(id -g)' > ~/.userid.sh",
-            "isBackground": true,
-            "problemMatcher": [],
-            "detail": "Exports the current user's user and group IDs so that the output files are owned by the correct user",
-            "presentation": {
-                "echo": false,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": false
-            }
-        },
-        {
-            "label": "Run Autoreduce container",
-            "detail": "Starts a daemon that contains the Autoreduce environment.",
-            "type": "shell",
-            "command": "source",
-            "promptOnClose": true,
-            "runOptions": {
-                "instanceLimit": 1,
-                "runOn": "folderOpen"
-            },
-            "args": [
-                "~/.userid.sh",
-                "&&",
-                "docker",
-                "run",
-                "--rm",
-                "--network=host",
-                "--mount",
-                "type=bind,source=${workspaceFolder},target=/autoreduce-frontend",
-                "--mount",
-                "type=bind,source=${workspaceFolder}/../autoreduce,target=/autoreduce",
-                "--mount",
-                "type=bind,source=$HOME/.autoreduce,target=/home/.autoreduce",
-                "--mount",
-                "type=bind,source=$HOME/.autoreduce/dev/reduced-data,target=/instrument",
-                "-e",
-                "HOME=/home",
-                "--user",
-                "$USERID",
-                "--name",
-                "autoreduce-debugpy",
-                "-it",
-                "autoreduction/dev",
-                "bash"
-            ],
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "group": "docker",
-                "clear": false
-            },
-            "problemMatcher": [],
-            "dependsOn": [
-                "Export UID:GID to $USERID",
-                "Make ~/.autoreduce/dev/reduced-data"
-            ]
-        },
-        {
-            "label": "(don't use directly) Exec runserver",
-            "detail": "Used by the debugging configuration. Don't manually use or the terminal will remain hanging until you manually attach to the --listen port",
-            "type": "shell",
-            "isBackground": true,
-            "command": "source ~/.userid.sh && docker exec -it autoreduce-debugpy python3 -m debugpy --listen 5679 --wait-for-client /autoreduce-frontend/autoreduce_frontend/manage.py runserver",
-            "group": "test",
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "(don't use directly) Exec pytest django",
-            "detail": "Used by the debugging configuration. Don't manually use",
-            "isBackground": true,
-            "type": "shell",
-            "command": "source ~/.userid.sh && docker exec -e DISPLAY=:1 -e RUNNING_VIA_PYTEST=true -e SELENIUM_REMOTE=1 -it autoreduce-debugpy python3 -m debugpy --listen 5681 --wait-for-client -m pytest -v /autoreduce-frontend/${relativeFileDirname}/${fileBasename}",
-            "group": "test",
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Kill autoreduce-debugpy",
-            "type": "shell",
-            "command": "docker kill autoreduce-debugpy",
-            "problemMatcher": [],
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
-            }
-        },
-        {
             "label": "Migrate all",
             "detail": "Migrates credentials and database (with PR fixtures)",
             "type": "shell",
@@ -149,21 +21,21 @@
         {
             "label": "Migrate credentials",
             "type": "shell",
-            "command": "source ~/.userid.sh && docker exec --user $USERID -it autoreduce-debugpy autoreduce-creds-migrate",
+            "command": "autoreduce-creds-migrate",
             "problemMatcher": [],
             "group": "build"
         },
         {
             "label": "Migrate database (with PR fixtures)",
             "type": "shell",
-            "command": "source ~/.userid.sh && docker exec --user $USERID -it autoreduce-debugpy bash -c 'python3 /autoreduce-frontend/autoreduce_frontend/manage.py migrate && python3 /autoreduce-frontend/autoreduce_frontend/manage.py loaddata super_user_fixture status_fixture pr_test'",
+            "command": "python ${workspaceFolder}/autoreduce_frontend/manage.py migrate && python ${workspaceFolder}/autoreduce_frontend/manage.py loaddata super_user_fixture status_fixture pr_test'",
             "problemMatcher": [],
             "group": "build"
         },
         {
             "label": "Migrate database (clean)",
             "type": "shell",
-            "command": "source ~/.userid.sh && docker exec --user $USERID -it autoreduce-debugpy python3 /autoreduce-frontend/autoreduce_frontend/manage.py migrate",
+            "command": "python ${workspaceFolder}/autoreduce_frontend/manage.py migrate",
             "isBackground": true,
             "problemMatcher": [],
             "group": "build"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,21 @@
-all:
+all: credentials migrate-with-fixtures
+
+dev:
 	python setup.py sdist bdist_wheel
 	twine upload --repository testpypi dist/*
 
 prod:
 	python setup.py sdist bdist_wheel
 	twine upload --repository pypi dist/*
+
+credentials:
+	autoreduce-creds-migrate
+
+migrate:
+	autoreduce-webapp-manage migrate
+
+migrate-with-fixtures: migrate
+	autoreduce-webapp-manage loaddata super_user_fixture status_fixture pr_test
+
+selenium:
+	docker run --network host --name selenium --rm -it -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-3-prerelease-20210422

--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -44,23 +44,12 @@ else:
 INTERNAL_IPS = ['localhost', '127.0.0.1']
 
 # Application definition
-ORM_INSTALL = [  # Minimal apps required to setup JUST the ORM - (increases ORM setup speed)
-    'autoreduce_frontend.autoreduce_webapp',
-    'autoreduce_db.reduction_viewer',
-    'autoreduce_db.instrument',
-]
-
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.humanize',
+    'django.contrib.admin', 'django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions',
+    'django.contrib.messages', 'django.contrib.staticfiles', 'django.contrib.humanize',
+    'autoreduce_frontend.autoreduce_webapp', 'autoreduce_frontend.generate_token', 'autoreduce_db.reduction_viewer',
+    'autoreduce_db.instrument', 'rest_framework.authtoken'
 ]
-
-INSTALLED_APPS = INSTALLED_APPS + ORM_INSTALL
 
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/autoreduce_frontend/autoreduce_webapp/urls.py
+++ b/autoreduce_frontend/autoreduce_webapp/urls.py
@@ -62,6 +62,9 @@ urlpatterns = [
     path('graph/', reduction_viewer_views.graph_home, name="graph"),
     path('graph/<str:instrument_name>', reduction_viewer_views.graph_instrument, name="graph_instrument"),
     path('stats/', reduction_viewer_views.stats, name="stats"),
+
+    # =======================GENERATE TOKEN========================== #
+    path('tokens/', include('generate_token.urls'))
 ]
 
 if settings.DEBUG:

--- a/autoreduce_frontend/generate_token/templates/delete_token.html
+++ b/autoreduce_frontend/generate_token/templates/delete_token.html
@@ -6,6 +6,6 @@
 <form method="post">
     {% csrf_token %}
     <p>Are you sure you want to delete token for user: <strong>{{ object.user }}</strong>?</p>
-    <input type="submit" value="Confirm">
+    <input id="generate-token-delete" type="submit" value="Confirm">
 </form>
 {% endblock %}

--- a/autoreduce_frontend/generate_token/templates/delete_token.html
+++ b/autoreduce_frontend/generate_token/templates/delete_token.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Help pages{% endblock %}
+{% load static %}
+
+{% block body %}
+<form method="post">
+    {% csrf_token %}
+    <p>Are you sure you want to delete token for user: <strong>{{ object.user }}</strong>?</p>
+    <input type="submit" value="Confirm">
+</form>
+{% endblock %}

--- a/autoreduce_frontend/generate_token/templates/generate_token.html
+++ b/autoreduce_frontend/generate_token/templates/generate_token.html
@@ -3,10 +3,10 @@
 {% load static %}
 
 {% block body %}
-<form method="POST">
+<form id="generate-token-form" method="POST">
     {% csrf_token %}
     {{ form }}
-    <button type="submit">Generate token</button>
+    <button id="generate-token-submit" type="submit">Generate token</button>
 </form>
 
 {% endblock %}

--- a/autoreduce_frontend/generate_token/templates/generate_token.html
+++ b/autoreduce_frontend/generate_token/templates/generate_token.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Help pages{% endblock %}
+{% load static %}
+
+{% block body %}
+<form method="POST">
+    {% csrf_token %}
+    {{ form }}
+    <button type="submit">Generate token</button>
+</form>
+
+{% endblock %}

--- a/autoreduce_frontend/generate_token/templates/show_tokens.html
+++ b/autoreduce_frontend/generate_token/templates/show_tokens.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Tokens{% endblock %}
+{% load static %}
+
+{% block body %}
+
+<a class="btn btn-primary" href="{% url 'token:generate' %}">Generate a new token</a>
+
+{% for token in token_list %}
+    <style>
+        .pointer{
+            cursor: pointer;
+        }
+    </style>
+    <script type="text/javascript">
+        function copyToClipboard(message) {
+            var textArea = document.createElement("textarea");
+            textArea.value = message;
+            textArea.style.opacity = "0";
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+
+
+            try {
+                return document.execCommand('copy');
+            } catch (err) {}
+
+            document.body.removeChild(textArea);
+        }
+
+        function copyWithSuccessCheck(elem){
+            copyToClipboard(elem.parentElement.dataset.tokenValue) ? elem.dataset.content='Copied to clipboard.' : elem.dataset.content='Failed to copy.';
+            setTimeout(()=> Array.prototype.slice.call(document.getElementsByClassName("popover")).forEach(element => {
+                document.body.removeChild(element);
+            }), 1500);
+        }
+    </script>
+
+    {% if error_message %}
+    <div class="alert alert-danger">{{ error_message }}</div>
+    {% endif %}
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">User</th>
+                <th scope="col">Token</th>
+                <th scope="col"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>{{ token.user }}</td>
+                <td data-token-value="{{ token }}">Click eye to reveal <a onclick="this.parentElement.textContent=this.parentElement.dataset.tokenValue"><i class="fa fa-eye pointer" aria-hidden="true"></i></a>
+                     or copy to clipboard <a data-toggle="popover" data-html="true" data-content="" data-trigger="click" data-placement="top" data-container="body" tabindex="0" onclick="copyWithSuccessCheck(this)"><i class="fa fa-clipboard pointer" aria-hidden="true"></i></a></td>
+                <td><a href="{% url 'token:delete' pk=token.pk %}">Delete</a></td>
+            </tr>
+        </tbody>
+
+</table>
+{% endfor %}
+{% endblock %}

--- a/autoreduce_frontend/generate_token/templates/show_tokens.html
+++ b/autoreduce_frontend/generate_token/templates/show_tokens.html
@@ -4,60 +4,59 @@
 
 {% block body %}
 
-<a class="btn btn-primary" href="{% url 'token:generate' %}">Generate a new token</a>
+<a id="generate-token" class="btn btn-primary" href="{% url 'token:generate' %}">Generate a new token</a>
 
-{% for token in token_list %}
-    <style>
-        .pointer{
-            cursor: pointer;
-        }
-    </style>
-    <script type="text/javascript">
-        function copyToClipboard(message) {
-            var textArea = document.createElement("textarea");
-            textArea.value = message;
-            textArea.style.opacity = "0";
-            document.body.appendChild(textArea);
-            textArea.focus();
-            textArea.select();
+<style>
+    .pointer{
+        cursor: pointer;
+    }
+</style>
+<script type="text/javascript">
+    function copyToClipboard(message) {
+        var textArea = document.createElement("textarea");
+        textArea.value = message;
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
 
 
-            try {
-                return document.execCommand('copy');
-            } catch (err) {}
+        try {
+            return document.execCommand('copy');
+        } catch (err) {}
 
-            document.body.removeChild(textArea);
-        }
+        document.body.removeChild(textArea);
+    }
 
-        function copyWithSuccessCheck(elem){
-            copyToClipboard(elem.parentElement.dataset.tokenValue) ? elem.dataset.content='Copied to clipboard.' : elem.dataset.content='Failed to copy.';
-            setTimeout(()=> Array.prototype.slice.call(document.getElementsByClassName("popover")).forEach(element => {
-                document.body.removeChild(element);
-            }), 1500);
-        }
-    </script>
+    function copyWithSuccessCheck(elem){
+        copyToClipboard(elem.parentElement.dataset.tokenValue) ? elem.dataset.content='Copied to clipboard.' : elem.dataset.content='Failed to copy.';
+        setTimeout(()=> Array.prototype.slice.call(document.getElementsByClassName("popover")).forEach(element => {
+            document.body.removeChild(element);
+        }), 1500);
+    }
+</script>
 
-    {% if error_message %}
-    <div class="alert alert-danger">{{ error_message }}</div>
-    {% endif %}
+{% if error_message %}
+<div class="alert alert-danger">{{ error_message }}</div>
+{% endif %}
 
-    <table class="table">
-        <thead>
-            <tr>
-                <th scope="col">User</th>
-                <th scope="col">Token</th>
-                <th scope="col"></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>{{ token.user }}</td>
-                <td data-token-value="{{ token }}">Click eye to reveal <a onclick="this.parentElement.textContent=this.parentElement.dataset.tokenValue"><i class="fa fa-eye pointer" aria-hidden="true"></i></a>
-                     or copy to clipboard <a data-toggle="popover" data-html="true" data-content="" data-trigger="click" data-placement="top" data-container="body" tabindex="0" onclick="copyWithSuccessCheck(this)"><i class="fa fa-clipboard pointer" aria-hidden="true"></i></a></td>
-                <td><a href="{% url 'token:delete' pk=token.pk %}">Delete</a></td>
-            </tr>
-        </tbody>
-
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">User</th>
+            <th scope="col">Token</th>
+            <th scope="col"></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for token in token_list %}
+        <tr>
+            <td class="token-user">{{ token.user }}</td>
+            <td class="token-value" data-token-value="{{ token }}">Click eye to reveal <a onclick="this.parentElement.textContent=this.parentElement.dataset.tokenValue"><i class="fa fa-eye pointer" aria-hidden="true"></i></a>
+                    or copy to clipboard <a data-toggle="popover" data-html="true" data-content="" data-trigger="click" data-placement="top" data-container="body" tabindex="0" onclick="copyWithSuccessCheck(this)"><i class="fa fa-clipboard pointer" aria-hidden="true"></i></a></td>
+            <td><a type="button" class="btn btn-danger token-delete" href="{% url 'token:delete' pk=token.pk %}">Delete</a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
 </table>
-{% endfor %}
 {% endblock %}

--- a/autoreduce_frontend/generate_token/tests.py
+++ b/autoreduce_frontend/generate_token/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/autoreduce_frontend/generate_token/tests.py
+++ b/autoreduce_frontend/generate_token/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/autoreduce_frontend/generate_token/urls.py
+++ b/autoreduce_frontend/generate_token/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from autoreduce_frontend.generate_token import views
+
+app_name = "token"
+
+urlpatterns = [
+    path("", views.ShowToken.as_view(), name="list"),
+    path("generate", views.GenerateTokenFormView.as_view(), name="generate"),
+    path("delete/<str:pk>", views.DeleteToken.as_view(), name="delete"),
+]

--- a/autoreduce_frontend/generate_token/views.py
+++ b/autoreduce_frontend/generate_token/views.py
@@ -1,0 +1,46 @@
+from typing import Any
+from django.http.request import HttpRequest
+
+from django import forms
+from django.http.response import HttpResponse, HttpResponseRedirect
+from django.views.generic.edit import DeleteView, FormView
+from django.views.generic import ListView
+from django.contrib.auth.models import User
+
+from django.urls import reverse_lazy
+from rest_framework.authtoken.models import Token
+
+
+class GenerateTokenForm(forms.Form):
+    user = forms.ModelChoiceField(queryset=User.objects.filter(auth_token__pk=None))
+
+
+class GenerateTokenFormView(FormView):
+    template_name = "generate_token.html"
+    form_class = GenerateTokenForm
+    success_url = reverse_lazy("token:list")
+
+    def form_valid(self, form) -> HttpResponse:
+        print(form)
+        obj, created = Token.objects.get_or_create(user=form.cleaned_data["user"])
+        if not created:
+            self.request.session["error_message"] = "User token already exists. You can only have 1 token per user."
+        return HttpResponseRedirect(self.get_success_url())
+
+
+class ShowToken(ListView):
+    template_name = "show_tokens.html"
+    model = Token
+    allow_empty = True
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        error_message = self.request.session.pop("error_message", "")
+        context['error_message'] = error_message
+        return context
+
+
+class DeleteToken(DeleteView):
+    template_name = "delete_token.html"
+    model = Token
+    success_url = reverse_lazy("token:list")

--- a/autoreduce_frontend/generate_token/views.py
+++ b/autoreduce_frontend/generate_token/views.py
@@ -1,13 +1,9 @@
-from typing import Any
-from django.http.request import HttpRequest
-
 from django import forms
-from django.http.response import HttpResponse, HttpResponseRedirect
-from django.views.generic.edit import DeleteView, FormView
-from django.views.generic import ListView
 from django.contrib.auth.models import User
-
+from django.http.response import HttpResponse, HttpResponseRedirect
 from django.urls import reverse_lazy
+from django.views.generic import ListView
+from django.views.generic.edit import DeleteView, FormView
 from rest_framework.authtoken.models import Token
 
 

--- a/autoreduce_frontend/selenium_tests/pages/generate_token/delete_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/generate_token/delete_page.py
@@ -14,7 +14,6 @@ from selenium.webdriver.remote.webelement import WebElement
 from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
 from autoreduce_frontend.selenium_tests.pages.page import Page
-from selenium.webdriver.support.ui import Select
 
 
 class DeleteTokenFormPage(Page, NavbarMixin, FooterMixin):

--- a/autoreduce_frontend/selenium_tests/pages/generate_token/delete_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/generate_token/delete_page.py
@@ -1,0 +1,34 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+"""
+Module for the help summary page model
+"""
+
+from django.urls.base import reverse
+from selenium.webdriver.remote.webelement import WebElement
+
+from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
+from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
+from autoreduce_frontend.selenium_tests.pages.page import Page
+from selenium.webdriver.support.ui import Select
+
+
+class DeleteTokenFormPage(Page, NavbarMixin, FooterMixin):
+    """
+    Page model class for help page
+    """
+    @staticmethod
+    def url_path() -> str:
+        """
+        Return the current URL of the page.
+        :return: (str) the url path
+        """
+        return reverse("token:delete")
+
+    def click_delete_token(self) -> WebElement:
+        """Clicks the delete token in the delete confirmation page"""
+        return self.driver.find_element_by_id("generate-token-delete").click()

--- a/autoreduce_frontend/selenium_tests/pages/generate_token/generate_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/generate_token/generate_page.py
@@ -1,0 +1,38 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+"""
+Module for the help summary page model
+"""
+
+from django.urls.base import reverse
+from selenium.webdriver.remote.webelement import WebElement
+
+from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
+from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
+from autoreduce_frontend.selenium_tests.pages.page import Page
+from selenium.webdriver.support.ui import Select
+
+
+class GenerateTokenFormPage(Page, NavbarMixin, FooterMixin):
+    """
+    Page model class for help page
+    """
+    @staticmethod
+    def url_path() -> str:
+        """
+        Return the current URL of the page.
+        :return: (str) the url path
+        """
+        return reverse("token:generate")
+
+    def click_generate_token(self) -> WebElement:
+        """Clicks generate in the token generation page"""
+        return self.driver.find_element_by_id("generate-token-submit").click()
+
+    def generate_form_users(self) -> Select:
+        """Grabs the users Select field in the generate new token form"""
+        return Select(self.driver.find_element_by_id("id_user"))

--- a/autoreduce_frontend/selenium_tests/pages/generate_token/list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/generate_token/list_page.py
@@ -1,0 +1,83 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+from autoreduce_frontend.selenium_tests.pages.generate_token.delete_page import DeleteTokenFormPage
+from typing import List
+
+from django.urls.base import reverse
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.common.keys import Keys
+
+from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
+from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
+from autoreduce_frontend.selenium_tests.pages.page import Page
+from autoreduce_frontend.selenium_tests.pages.generate_token.generate_page import GenerateTokenFormPage
+
+
+class GenerateTokenListPage(Page, NavbarMixin, FooterMixin):
+    """
+    Page model class for help page
+    """
+    @staticmethod
+    def url_path() -> str:
+        """
+        Return the current URL of the page.
+        :return: (str) the url path
+        """
+        return reverse("token:list")
+
+    def click_generate_token(self) -> GenerateTokenFormPage:
+        """
+        Get the contents of the sidenav.
+        :return: (List) A list of <li> WebElements in #sidenav-contents
+        """
+        self.driver.find_element_by_id("generate-token").click()
+        return GenerateTokenFormPage(self.driver)
+
+    def token_usernames(self) -> List[WebElement]:
+        """Return the usernames for all generated tokens"""
+        return self.driver.find_elements_by_class_name("token-user")
+
+    def token_values(self) -> List[WebElement]:
+        """
+        Return the values for all generated tokens
+
+        Note: this doesn't return the literal token value, but the field which
+        the user can click to reveal/copy the value
+        """
+        return self.driver.find_elements_by_class_name("token-value")
+
+    def click_delete_first(self) -> DeleteTokenFormPage:
+        """Clicks the delete on the first token"""
+        token_deletes = self.driver.find_elements_by_class_name("token-delete")
+        token_deletes[0].click()
+        return DeleteTokenFormPage(self.driver)
+
+    def token_eye_views(self) -> List[WebElement]:
+        """Return all "eye" icons, that reveal the value of the token"""
+        return self.driver.find_elements_by_class_name("fa-eye")
+
+    def token_copy_clipboards(self) -> List[WebElement]:
+        """Return all "clipboard" icons, that copy to clipboard"""
+        return self.driver.find_elements_by_class_name("fa-clipboard")
+
+    def paste_and_verify(self, expected: str):
+        """
+        Pastes the value of the clipboard and verifies that it matches the expected parameter
+
+        Done by creating a new textarea element, pasting the value in it with CTRL+V, then
+        comparing against the expected parameter.
+
+        A bit of a workaround, but way easier & understandable than accessing the system clipboard!
+        """
+        self.driver.execute_script("""
+        let obj = document.createElement("textarea");
+        obj.id="selenium-test";
+        document.body.appendChild(obj);
+        """)
+        obj = self.driver.find_element_by_id("selenium-test")
+        obj.send_keys(Keys.CONTROL, "v")
+        assert obj.get_attribute("value") == expected

--- a/autoreduce_frontend/selenium_tests/pages/page.py
+++ b/autoreduce_frontend/selenium_tests/pages/page.py
@@ -8,15 +8,18 @@
 Module containing the base Page object class
 """
 from abc import ABC, abstractmethod
+from typing import Union
 
 from autoreduce_frontend.selenium_tests import configuration
+
+from selenium import webdriver
 
 
 class Page(ABC):
     """
     Abstract base class for page object model classes
     """
-    def __init__(self, driver):
+    def __init__(self, driver: Union[webdriver.Chrome, webdriver.Remote]):
         self.driver = driver
 
     @abstractmethod

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from rest_framework.authtoken.models import Token
+
+from autoreduce_frontend.reduction_viewer import views
+from autoreduce_frontend.autoreduce_webapp.icat_cache import DEFAULT_MESSAGE
+from autoreduce_frontend.autoreduce_webapp.view_utils import ICATConnectionException
+from autoreduce_frontend.selenium_tests.pages.error_page import ErrorPage
+from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, FooterTestMixin, NavbarTestMixin, AccessibilityTestMixin
+from autoreduce_frontend.selenium_tests.pages.generate_token.list_page import GenerateTokenListPage
+
+
+class TestGenerateTokenPage(BaseTestCase):  #NavbarTestMixin, FooterTestMixin,AccessibilityTestMixin):
+    """
+    Test cases for the error page
+    """
+    fixtures = BaseTestCase.fixtures
+
+    def setUp(self) -> None:
+        """
+        Sets up the ErrorPage object
+        """
+        super().setUp()
+        self.page = GenerateTokenListPage(self.driver)
+        self.page.launch()
+        self._action_generate_token()
+
+    def _action_generate_token(self):
+        form_page = self.page.click_generate_token()
+        form_page.generate_form_users().select_by_visible_text("super")
+        form_page.click_generate_token()
+
+    def test_generate_token_for_user(self):
+        """
+        Generate token for user with the expected name
+        """
+        usernames = self.page.token_usernames()
+        assert len(usernames) == 1
+        assert usernames[0].text == "super"
+
+    def test_generate_and_view(self):
+        """
+        Generate a token and click the eye to reveal it
+        """
+        token_values = self.page.token_values()
+        assert len(token_values) == 1
+        assert "Click eye to reveal" in token_values[0].text
+        assert "or copy to clipboard" in token_values[0].text
+
+        eye_views = self.page.token_eye_views()
+        token_values = self.page.token_values()
+        assert len(eye_views) == 1
+        eye_views[0].click()
+
+        token_values = self.page.token_values()
+        assert len(token_values) == 1
+        assert str(Token.objects.first()) in token_values[0].text
+
+    def test_generate_and_delete(self):
+        """Generate a token and delete it"""
+        delete_page = self.page.click_delete_first()
+        delete_page.click_delete_token()
+
+        token_values = self.page.token_values()
+        assert len(token_values) == 0
+        assert Token.objects.count() == 0
+
+    def test_generate_and_copy(self):
+        """
+        Generate a token, copy it to the clipboard, then paste it and verify the value.
+
+        The pasting appends a new element in the window, calls CTRL+V on it, then compares its value to the token value.
+        """
+        token_values = self.page.token_values()
+        assert len(token_values) == 1
+        assert "Click eye to reveal" in token_values[0].text
+        assert "or copy to clipboard" in token_values[0].text
+
+        clipboards = self.page.token_copy_clipboards()
+        token_values = self.page.token_values()
+        assert len(clipboards) == 1
+        clipboards[0].click()
+
+        self.page.paste_and_verify(str(Token.objects.first()))

--- a/autoreduce_frontend/templates/navbar.html
+++ b/autoreduce_frontend/templates/navbar.html
@@ -41,6 +41,7 @@
                         <li>
                             <a href="{% url 'help' %} ">Help</a>
                         </li>
+                        <li><a href="{% url 'token:list' %}">Tokens</a></li>
                     {% endif %}
                     <li>
                         <a href="{% url 'logout' %}" id="logout">Logout</a>

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name=PACKAGE_NAME,
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
       install_requires=[
-          "autoreduce_utils==22.0.0.dev2", "autoreduce_db==22.0.0.dev3", "autoreduce_qp==22.0.0.dev1", "Django==3.2.4",
+          "autoreduce_utils==22.0.0.dev3", "autoreduce_db==22.0.0.dev4", "autoreduce_qp==22.0.0.dev1", "Django==3.2.4",
           "django_extensions==3.1.3", "django-user-agents==0.4.0", "djangorestframework==3.12.4"
       ],
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name=PACKAGE_NAME,
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
       install_requires=[
-          "autoreduce_utils==22.0.0.dev3", "autoreduce_db==22.0.0.dev4", "autoreduce_qp==22.0.0.dev1", "Django==3.2.4",
+          "autoreduce_utils==22.0.0.dev3", "autoreduce_db==22.0.0.dev4", "autoreduce_qp==22.0.0.dev2", "Django==3.2.4",
           "django_extensions==3.1.3", "django-user-agents==0.4.0", "djangorestframework==3.12.4"
       ],
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name=PACKAGE_NAME,
       url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
       install_requires=[
           "autoreduce_utils==22.0.0.dev2", "autoreduce_db==22.0.0.dev3", "autoreduce_qp==22.0.0.dev1", "Django==3.2.4",
-          "django_extensions==3.1.3", "django-user-agents==0.4.0"
+          "django_extensions==3.1.3", "django-user-agents==0.4.0", "djangorestframework==3.12.4"
       ],
       packages=find_packages(),
       package_data={"": data_files},

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ for loc in data_locations:
 print(data_files)
 
 setup(name=PACKAGE_NAME,
-      version="22.0.0.dev0",
+      version="22.0.0.dev1",
       description="The frontend of the ISIS Autoreduction service",
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce-frontend/",


### PR DESCRIPTION
### Summary of work
Adds a new "Tokens" page, visible only to admins:
![image](https://user-images.githubusercontent.com/9135965/123612312-54d56880-d7fa-11eb-9731-fa3128274980.png)

This allows generation of tokens for specific users.

These tokens are saved in the same DB that the Rest API will connect to, and will be used for authentication when submitting runs.

Also adds selenium tests for the new workflows in this new `generate_token` app.

### How to test your work
To test:

- [Start the webapp](https://github.com/ISISScientificComputing/autoreduce/wiki/Start-here-(getting-the-code---installation)#installing-autoreduce). You don't need ActiveMQ or the queue processor as this is just a webapp addition
- Go to `/tokens`
- Click "Generate". Play around with it.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes [AR-1446](https://autoreduce.atlassian.net/browse/AR-1446)


**Before merging ensure the release notes have been updated**