### PR TITLE
Displays better names when generating a token for a user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,5 @@ migrate-with-fixtures: migrate
 	autoreduce-webapp-manage loaddata super_user_fixture status_fixture pr_test
 
 selenium:
+	docker kill selenium
 	docker run --network host --name selenium --rm -it -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-3-prerelease-20210422

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ migrate-with-fixtures: migrate
 	autoreduce-webapp-manage loaddata super_user_fixture status_fixture pr_test
 
 selenium:
-	docker kill selenium
-	docker run --network host --name selenium --rm -it -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-3-prerelease-20210422
+	docker kill selenium || echo "Selenium container isn't already running, just starting it."
+	docker run --network host --name selenium --rm -d -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-3-prerelease-20210422

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/additional_users.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/additional_users.json
@@ -1,0 +1,15 @@
+[
+  {
+    "model": "auth.user",
+    "pk": 2,
+    "fields": {
+      "password": "pbkdf2_sha256$216000$IbJL1BmcD5Pv$vYPUY0ZQwqX59nJ30aCdzrNPXkxFc7DO6xQW0upezwo=",
+      "username": "123456",
+      "first_name": "Test",
+      "last_name": "User",
+      "is_superuser": 1,
+      "is_staff": 1,
+      "date_joined": "2021-01-27 16:30:47.129251+00:00"
+    }
+  }
+]

--- a/autoreduce_frontend/autoreduce_webapp/view_utils.py
+++ b/autoreduce_frontend/autoreduce_webapp/view_utils.py
@@ -103,7 +103,7 @@ def require_admin(func):
 
 def get_notifications(request):
     """
-    Gets the notifications that the user should be able to see
+    Gets the notifications that the user should be able to see.
     """
     if request.user.is_staff and request.user.is_authenticated:
         return Notification.objects.filter(is_active=True)

--- a/autoreduce_frontend/autoreduce_webapp/view_utils.py
+++ b/autoreduce_frontend/autoreduce_webapp/view_utils.py
@@ -101,6 +101,16 @@ def require_admin(func):
     return request_processor
 
 
+def get_notifications(request):
+    """
+    Gets the notifications that the user should be able to see
+    """
+    if request.user.is_staff and request.user.is_authenticated:
+        return Notification.objects.filter(is_active=True)
+    else:
+        return Notification.objects.filter(is_active=True, is_staff_only=False)
+
+
 def render_with(template):
     """
     Decorator for Django views that sends returned dict to render function
@@ -114,10 +124,7 @@ def render_with(template):
                 output['request'] = request
 
             # pylint: disable=no-member
-            if request.user.is_staff and request.user.is_authenticated:
-                notifications = Notification.objects.filter(is_active=True)
-            else:
-                notifications = Notification.objects.filter(is_active=True, is_staff_only=False)
+            notifications = get_notifications(request)
 
             if 'notifications' not in output:
                 output['notifications'] = notifications

--- a/autoreduce_frontend/generate_token/forms.py
+++ b/autoreduce_frontend/generate_token/forms.py
@@ -14,7 +14,7 @@ class VerboseUserChoiceField(ModelChoiceField):
     def __init__(self, *args, **kwargs):
         super(VerboseUserChoiceField, self).__init__(*args, **kwargs)
 
-    def label_from_instance(self, obj: User):
+    def label_from_instance(self, obj: User) -> str:
         """
         Returns a custom made label for the given object.
 

--- a/autoreduce_frontend/generate_token/forms.py
+++ b/autoreduce_frontend/generate_token/forms.py
@@ -1,0 +1,28 @@
+from django import forms
+from django.contrib.auth.models import User
+from django.forms import ModelChoiceField
+
+
+class VerboseUserChoiceField(ModelChoiceField):
+    """
+    Subclasses Django's ModelChoiceField and overrides the label_from_instance method to
+    display the first+last name+username instead of the just the username of the User model.
+
+    This is because the usernames stored in the database are the user ID's, which makes it hard to
+    visually recognise which user is which.
+    """
+    def __init__(self, *args, **kwargs):
+        super(VerboseUserChoiceField, self).__init__(*args, **kwargs)
+
+    def label_from_instance(self, obj: User):
+        """
+        Returns a custom made label for the given object.
+
+        :param obj: The object to get the label for.
+        :return: A string to use as the label.
+        """
+        return f"{obj.first_name} {obj.last_name} ({obj.username})"
+
+
+class GenerateTokenForm(forms.Form):
+    user = VerboseUserChoiceField(queryset=User.objects.filter(auth_token__pk=None).order_by("first_name"))

--- a/autoreduce_frontend/generate_token/templates/show_tokens.html
+++ b/autoreduce_frontend/generate_token/templates/show_tokens.html
@@ -51,7 +51,7 @@
     <tbody>
         {% for token in token_list %}
         <tr>
-            <td class="token-user">{{ token.user }}</td>
+            <td class="token-user">{{ token.user.first_name }} {{ token.user.last_name }} ({{ token.user.username }})</td>
             <td class="token-value" data-token-value="{{ token }}">Click eye to reveal <a onclick="this.parentElement.textContent=this.parentElement.dataset.tokenValue"><i class="fa fa-eye pointer" aria-hidden="true"></i></a>
                     or copy to clipboard <a data-toggle="popover" data-html="true" data-content="" data-trigger="click" data-placement="top" data-container="body" tabindex="0" onclick="copyWithSuccessCheck(this)"><i class="fa fa-clipboard pointer" aria-hidden="true"></i></a></td>
             <td><a type="button" class="btn btn-danger token-delete" href="{% url 'token:delete' pk=token.pk %}">Delete</a></td>

--- a/autoreduce_frontend/generate_token/views.py
+++ b/autoreduce_frontend/generate_token/views.py
@@ -1,14 +1,10 @@
-from django import forms
-from django.contrib.auth.models import User
 from django.http.response import HttpResponse, HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import ListView
 from django.views.generic.edit import DeleteView, FormView
 from rest_framework.authtoken.models import Token
 
-
-class GenerateTokenForm(forms.Form):
-    user = forms.ModelChoiceField(queryset=User.objects.filter(auth_token__pk=None))
+from autoreduce_frontend.generate_token.forms import GenerateTokenForm
 
 
 class GenerateTokenFormView(FormView):

--- a/autoreduce_frontend/generate_token/views.py
+++ b/autoreduce_frontend/generate_token/views.py
@@ -1,3 +1,4 @@
+from autoreduce_frontend.autoreduce_webapp.view_utils import get_notifications
 from django.http.response import HttpResponse, HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import ListView
@@ -27,6 +28,7 @@ class ShowToken(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["notifications"] = get_notifications(self.request)
         error_message = self.request.session.pop("error_message", "")
         context['error_message'] = error_message
         return context

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
@@ -1,17 +1,11 @@
-import unittest
-from unittest.mock import Mock, patch
-
 from rest_framework.authtoken.models import Token
 
-from autoreduce_frontend.reduction_viewer import views
-from autoreduce_frontend.autoreduce_webapp.icat_cache import DEFAULT_MESSAGE
-from autoreduce_frontend.autoreduce_webapp.view_utils import ICATConnectionException
-from autoreduce_frontend.selenium_tests.pages.error_page import ErrorPage
-from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, FooterTestMixin, NavbarTestMixin, AccessibilityTestMixin
+from autoreduce_frontend.selenium_tests.tests.base_tests import (BaseTestCase, FooterTestMixin, NavbarTestMixin,
+                                                                 AccessibilityTestMixin)
 from autoreduce_frontend.selenium_tests.pages.generate_token.list_page import GenerateTokenListPage
 
 
-class TestGenerateTokenPage(BaseTestCase):  #NavbarTestMixin, FooterTestMixin,AccessibilityTestMixin):
+class TestGenerateTokenPage(BaseTestCase, NavbarTestMixin, FooterTestMixin, AccessibilityTestMixin):
     """
     Test cases for the error page
     """

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
@@ -15,7 +15,7 @@ class TestGenerateTokenPage(BaseTestCase):  #NavbarTestMixin, FooterTestMixin,Ac
     """
     Test cases for the error page
     """
-    fixtures = BaseTestCase.fixtures
+    fixtures = BaseTestCase.fixtures + ["additional_users"]
 
     def setUp(self) -> None:
         """
@@ -28,7 +28,7 @@ class TestGenerateTokenPage(BaseTestCase):  #NavbarTestMixin, FooterTestMixin,Ac
 
     def _action_generate_token(self):
         form_page = self.page.click_generate_token()
-        form_page.generate_form_users().select_by_visible_text("super")
+        form_page.generate_form_users().select_by_visible_text("(super)")
         form_page.click_generate_token()
 
     def test_generate_token_for_user(self):
@@ -83,3 +83,16 @@ class TestGenerateTokenPage(BaseTestCase):  #NavbarTestMixin, FooterTestMixin,Ac
         clipboards[0].click()
 
         self.page.paste_and_verify(str(Token.objects.first()))
+
+    def test_users_label_correct(self):
+        """
+        Test that users with first_name and last_name are displayed correctly
+        """
+        # clear all premade tokens
+        Token.objects.all().delete()
+        form_page = self.page.click_generate_token()
+        # 3 because top option is ------, and then the 2 users from the fixture
+        assert len(form_page.generate_form_users().options) == 3
+        assert form_page.generate_form_users().options[0].text == "---------"
+        assert form_page.generate_form_users().options[1].text == "(super)"
+        assert form_page.generate_form_users().options[2].text == "Test User (123456)"

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_generate_token_page.py
@@ -31,7 +31,7 @@ class TestGenerateTokenPage(BaseTestCase, NavbarTestMixin, FooterTestMixin, Acce
         """
         usernames = self.page.token_usernames()
         assert len(usernames) == 1
-        assert usernames[0].text == "super"
+        assert usernames[0].text == "(super)"
 
     def test_generate_and_view(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ print(data_files)
 
 setup(
     name=PACKAGE_NAME,
-    version="22.0.0.dev4",  # when updating the version here make sure to also update webapp.D
+    version="22.0.0.dev5",  # when updating the version here make sure to also update webapp.D
     description="The frontend of the ISIS Autoreduction service",
     author="ISIS Autoreduction Team",
     url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
     install_requires=[
-        "autoreduce_qp==22.0.0.dev4", "Django==3.2.4", "django_extensions==3.1.3", "django-user-agents==0.4.0",
+        "autoreduce_qp==22.0.0.dev5", "Django==3.2.4", "django_extensions==3.1.3", "django-user-agents==0.4.0",
         "djangorestframework==3.12.4"
     ],
     packages=find_packages(),


### PR DESCRIPTION
### Summary of work
Adds a custom form to override the label displayed in the choice field. This allows us to display it in a more readable way showing first + last name + username (which is a number)

### How to test your work
1. Checkout this branch & migrate the database to get the `auth.token` table
2. Open the webapp and go to the token tab, or once you have it running follow http://127.0.0.1:8000/tokens/
3. Click on generate tokens and then the dropdown field
4. It should show (super) and a bunch of names, check https://autoreduce.atlassian.net/browse/AR-1499 to see how it looks before this PR
5. Tests should also pass

Fixes AR-1499


**Before merging ensure the release notes have been updated**