### PR TITLE
1423 keep pagination ar 1423

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/fixtures/eleven_runs.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/eleven_runs.json
@@ -1,0 +1,330 @@
+[
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 1,
+        "fields": {
+            "run_number": 99999,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 2,
+        "fields": {
+            "run_number": 100000,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 3,
+        "fields": {
+            "run_number": 100001,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 4,
+        "fields": {
+            "run_number": 100002,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 5,
+        "fields": {
+            "run_number": 100003,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 6,
+        "fields": {
+            "run_number": 100004,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 7,
+        "fields": {
+            "run_number": 100005,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 8,
+        "fields": {
+            "run_number": 100006,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 9,
+        "fields": {
+            "run_number": 100007,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 10,
+        "fields": {
+            "run_number": 100008,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 11,
+        "fields": {
+            "run_number": 100009,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "pk": 1,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "pk": 2,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "reduction_viewer.experiment",
+        "pk": 1,
+        "fields": {
+            "reference_number": 1234567
+        }
+    },
+    {
+        "model": "reduction_viewer.instrument",
+        "pk": 1,
+        "fields": {
+            "name": "TestInstrument",
+            "is_active": true,
+            "is_paused": false
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 1,
+        "fields": {
+            "name": "std_var",
+            "value": "value1",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 2,
+        "fields": {
+            "name": "adv_var",
+            "value": "advanced value1",
+            "type": "text",
+            "is_advanced": true,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 3,
+        "fields": {
+            "name": "std_var",
+            "value": "value2",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 4,
+        "fields": {
+            "name": "adv_var",
+            "value": "advanced value2",
+            "type": "text",
+            "is_advanced": true,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 1,
+        "fields": {
+            "variable_ptr_id": 1,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 2,
+        "fields": {
+            "variable_ptr_id": 2,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 3,
+        "fields": {
+            "variable_ptr_id": 3,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 100000,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 4,
+        "fields": {
+            "variable_ptr_id": 4,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 100000,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 1,
+        "fields": {
+            "variable_id": 1,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 2,
+        "fields": {
+            "variable_id": 2,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 3,
+        "fields": {
+            "variable_id": 3,
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 4,
+        "fields": {
+            "variable_id": 4,
+            "reduction_run_id": 2
+        }
+    }
+]

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -349,7 +349,6 @@ def runs_list(request, instrument=None):
 
         has_variables = bool(current_variables)
 
-
         context_dictionary = {
             'instrument': instrument_obj,
             'instrument_name': instrument_obj.name,

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -349,7 +349,6 @@ def runs_list(request, instrument=None):
 
         has_variables = bool(current_variables)
 
-        #page = request.GET.get('page', '')
 
         context_dictionary = {
             'instrument': instrument_obj,

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -370,11 +370,13 @@ def runs_list(request, instrument=None):
             context_dictionary['experiments'] = experiments_and_runs
         else:
             max_items_per_page = request.GET.get('pagination', 10)
-            custom_paginator = CustomPaginator(page_type=sort_by,
+            custom_paginator = CustomPaginator(
+                page_type=sort_by,
                                                query_set=runs,
                                                items_per_page=max_items_per_page,
                                                page_tolerance=3,
-                                               current_page=request.GET.get('page', 1))
+                current_page=request.GET.get('page', 1),
+            )
             context_dictionary['paginator'] = custom_paginator
             context_dictionary['last_page_index'] = len(custom_paginator.page_list)
             context_dictionary['max_items'] = max_items_per_page

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -16,11 +16,8 @@ can be more confident we are not affecting the execution
 import json
 import logging
 import operator
-import os
 import traceback
 
-from autoreduce_db.reduction_viewer.models import (Experiment, Instrument, ReductionRun, Status)
-from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 from django.contrib.auth import authenticate, login
 from django.contrib.auth import logout as django_logout
 from django.contrib.auth.models import User
@@ -30,7 +27,9 @@ from django.http import HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.http import url_has_allowed_host_and_scheme
 
-from autoreduce_frontend.autoreduce_webapp.icat_cache import (ICATCache, ICATConnectionException)
+from autoreduce_db.reduction_viewer.models import Experiment, Instrument, ReductionRun, Status
+from autoreduce_qp.queue_processor.variable_utils import VariableUtils
+from autoreduce_frontend.autoreduce_webapp.icat_cache import ICATCache, ICATConnectionException
 from autoreduce_frontend.autoreduce_webapp.settings import (ALLOWED_HOSTS, DEVELOPMENT_MODE, UOWS_LOGIN_URL,
                                                             USER_ACCESS_CHECKS)
 from autoreduce_frontend.autoreduce_webapp.uows_client import UOWSClient

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -258,6 +258,9 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
         has_reduce_vars = bool(current_variables)
         has_run_variables = bool(run.run_variables.count())
         page = request.GET.get('page', 1)
+        items_per_page = request.GET.get('pagination', '10')
+        page_type = request.GET.get('sort', 'run')
+
         context_dictionary = {
             'run': run,
             'run_number': run_number,
@@ -271,7 +274,9 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
             'has_reduce_vars': has_reduce_vars,
             'has_run_variables': has_run_variables,
             'data_analysis_link_url': data_analysis_link_url,
-            'current_page': page
+            'current_page': page,
+            'items_per_page': items_per_page,
+            'page_type': page_type,
         }
 
     except PermissionDenied:
@@ -372,9 +377,9 @@ def runs_list(request, instrument=None):
             max_items_per_page = request.GET.get('pagination', 10)
             custom_paginator = CustomPaginator(
                 page_type=sort_by,
-                                               query_set=runs,
-                                               items_per_page=max_items_per_page,
-                                               page_tolerance=3,
+                query_set=runs,
+                items_per_page=max_items_per_page,
+                page_tolerance=3,
                 current_page=request.GET.get('page', 1),
             )
             context_dictionary['paginator'] = custom_paginator

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -224,7 +224,7 @@ def fail_queue(request):
 @check_permissions
 @render_with('run_summary.html')
 # pylint:disable=no-member,too-many-locals
-def run_summary(_, instrument_name=None, run_number=None, run_version=0):
+def run_summary(request, instrument_name=None, run_number=None, run_version=0):
     """
     Render run summary
     """
@@ -258,6 +258,7 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
 
         has_reduce_vars = bool(current_variables)
         has_run_variables = bool(run.run_variables.count())
+        page = request.GET.get('page', 1)
         context_dictionary = {
             'run': run,
             'run_number': run_number,
@@ -270,7 +271,8 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
             'started_by': started_by,
             'has_reduce_vars': has_reduce_vars,
             'has_run_variables': has_run_variables,
-            'data_analysis_link_url': data_analysis_link_url
+            'data_analysis_link_url': data_analysis_link_url,
+            'current_page': page
         }
 
     except PermissionDenied:
@@ -343,6 +345,8 @@ def runs_list(request, instrument=None):
 
         has_variables = bool(current_variables)
 
+        #page = request.GET.get('page', '')
+
         context_dictionary = {
             'instrument': instrument_obj,
             'instrument_name': instrument_obj.name,
@@ -353,7 +357,7 @@ def runs_list(request, instrument=None):
             'filtering': filter_by,
             'sort': sort_by,
             'has_variables': has_variables,
-            'error_reason': error_reason
+            'error_reason': error_reason,
         }
 
         if filter_by == 'experiment':

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -137,7 +137,7 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
     def _do_run_button(self, url):
         def run_button_clicked_successfully(button, url, driver):
             button.click()
-            return url in driver.current_url
+            return driver.current_url.split("?")[0].endswith(url)
 
         button = self.driver.find_element_by_css_selector(f'[href*="{url}"]')
         WebDriverWait(self.driver, 10).until(partial(run_button_clicked_successfully, button, url))

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -132,3 +132,13 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         Returns all image elements on the page.
         """
         return self.driver.find_elements_by_class_name("js-plotly-plot")
+
+    def get_top_run(self):
+        """Get the top run using the element's id"""
+        return self.driver.find_element_by_id('cancel')
+
+    def click_cancel_btn(self):
+        """"""
+        from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
+        self.cancel_button.click()
+        return RunsListPage(self.driver, self.instrument)

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -7,14 +7,15 @@
 """
 Module for the run summary page model
 """
+from functools import partial
 from typing import List
 
 from django.urls.base import reverse
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support.wait import WebDriverWait
 from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
-from autoreduce_frontend.selenium_tests.pages.component_mixins.rerun_form_mixin import \
-    RerunFormMixin
+from autoreduce_frontend.selenium_tests.pages.component_mixins.rerun_form_mixin import RerunFormMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.tour_mixin import TourMixin
 from autoreduce_frontend.selenium_tests.pages.page import Page
 
@@ -133,12 +134,17 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         """
         return self.driver.find_elements_by_class_name("js-plotly-plot")
 
-    def get_top_run(self):
-        """Get the top run using the element's id"""
-        return self.driver.find_element_by_id('cancel')
+    def _do_run_button(self, url):
+        def run_button_clicked_successfully(button, url, driver):
+            button.click()
+            return url in driver.current_url
+
+        button = self.driver.find_element_by_css_selector(f'[href*="{url}"]')
+        WebDriverWait(self.driver, 10).until(partial(run_button_clicked_successfully, button, url))
 
     def click_cancel_btn(self):
-        """"""
+        """Click the cancel button and return a RunsListPage object."""
         from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
-        self.cancel_button.click()
+
+        self._do_run_button(reverse("runs:list", kwargs={"instrument": self.instrument}))
         return RunsListPage(self.driver, self.instrument)

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -59,3 +59,7 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
     def alert_message_text(self) -> str:
         """Get the the from the alert message"""
         return self.driver.find_element_by_id("alert_message").text.strip()
+
+    def get_top_run(self):
+        """Get the top run using the element's id"""
+        return self.driver.find_element_by_id("top-run-number")

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -61,5 +61,16 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         return self.driver.find_element_by_id("alert_message").text.strip()
 
     def get_top_run(self):
-        """Get the top run using the element's id"""
+        """Get the top run using the element's id."""
         return self.driver.find_element_by_id("top-run-number")
+
+    def click_page(self, title):
+        """Click the page navigation button matching the given title on the instrument list page."""
+        btns = self.driver.find_elements_by_tag_name("button")
+
+        for btn in btns:
+            if btn.get_attribute("title") == title:
+                btn.click()
+                break
+        else:
+            raise NoSuchElementException

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -11,6 +11,7 @@ from typing import List
 
 from django.urls import reverse
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.ui import Select
 from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.tour_mixin import TourMixin
@@ -60,12 +61,12 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         """Get the the from the alert message"""
         return self.driver.find_element_by_id("alert_message").text.strip()
 
-    def get_top_run(self):
+    def get_top_run(self) -> None:
         """Get the top run using the element's id."""
         return self.driver.find_element_by_id("top-run-number")
 
-    def click_page(self, title):
-        """Click the page navigation button matching the given title on the instrument list page."""
+    def click_page(self, title: str) -> None:
+        """Click the page navigation button matching the given title."""
         btns = self.driver.find_elements_by_tag_name("button")
 
         for btn in btns:
@@ -74,3 +75,18 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
                 break
         else:
             raise NoSuchElementException
+
+    def update_items_per_page_option(self, pagination: int) -> None:
+        """Select the supplied pagination option from the 'Items per page' combo box."""
+        pagination_select = Select(self.driver.find_element_by_id("pagination_select"))
+        pagination_select.select_by_visible_text(str(pagination))
+
+    def update_sort_by_option(self, sort_by: str) -> None:
+        """Select the supplied sort by option from the 'Sort by' combo box."""
+        pagination_select = Select(self.driver.find_element_by_id("sort_select"))
+        pagination_select.select_by_visible_text(sort_by)
+
+    def click_apply_filters(self) -> None:
+        "Click the 'Apply filters' button."
+        btn = self.driver.find_element_by_id("apply_filters")
+        btn.click()

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
@@ -18,7 +18,7 @@ from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, Fo
 
 
 # pylint:disable=no-member
-class TestRunSummaryPage(BaseTestCase):
+class TestRunSummaryPage(BaseTestCase, FooterTestMixin, NavbarTestMixin):
     """
     Test cases for the InstrumentSummary page when the Rerun form is NOT visible
     """

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
@@ -18,7 +18,7 @@ from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, Fo
 
 
 # pylint:disable=no-member
-class TestRunSummaryPage(NavbarTestMixin, BaseTestCase, FooterTestMixin):
+class TestRunSummaryPage(BaseTestCase):
     """
     Test cases for the InstrumentSummary page when the Rerun form is NOT visible
     """

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
@@ -9,13 +9,12 @@ Selenium tests for the runs summary page
 """
 
 from autoreduce_qp.systemtests.utils.data_archive import DataArchive
-
 from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
-from autoreduce_frontend.selenium_tests.tests.base_tests import NavbarTestMixin, BaseTestCase, FooterTestMixin, \
-    AccessibilityTestMixin
+from autoreduce_frontend.selenium_tests.tests.base_tests import (AccessibilityTestMixin, BaseTestCase, FooterTestMixin,
+                                                                 NavbarTestMixin)
 
 
-class TestRunsListPage(NavbarTestMixin, BaseTestCase, FooterTestMixin, AccessibilityTestMixin):
+class TestRunsListPage(BaseTestCase, NavbarTestMixin, FooterTestMixin, AccessibilityTestMixin):
     """
     Test cases for the InstrumentSummary page
     """
@@ -63,7 +62,7 @@ class TestRunsListPage(NavbarTestMixin, BaseTestCase, FooterTestMixin, Accessibi
         data_archive.delete()
 
 
-class TestParameters(BaseTestCase):
+class TestParameters(BaseTestCase, NavbarTestMixin, FooterTestMixin, AccessibilityTestMixin):
     """Test cases for the InstrumentSummary page queries."""
 
     fixtures = BaseTestCase.fixtures + ["eleven_runs"]
@@ -74,18 +73,16 @@ class TestParameters(BaseTestCase):
         self.instrument_name = "TestInstrument"
         self.page = RunsListPage(self.driver, self.instrument_name)
 
-    def test_page_num_query(self, page=None):
-        """Test that the given page number is a query for the page."""
+    def _test_page_query(self, query, page=None):
+        """Test that the given query is in a run's URL after clicking a run and then clicking the 'Back to
+        <InstrumentName> runs' button."""
         # Launch the web page if no page arg supplied
         if not page:
             self.page.launch()
             page = 1
 
-        # Evalutes to "page=<page>"
-        page_query = f"{page=}"
-
         # Check if page query is in the href
-        assert page_query in self.page.get_top_run().get_attribute('href')
+        assert query in self.page.get_top_run().get_attribute('href')
 
         # Get the number of the top run
         top_run_num = int(self.page.get_top_run().text)
@@ -93,24 +90,43 @@ class TestParameters(BaseTestCase):
         # Click the top run and assign a RunSummaryPage object
         run_summary_page = self.page.click_run(top_run_num)
 
-        # Check if the page query is in the url for the summary page
-        assert page_query in run_summary_page.driver.current_url
+        # Check if the query is in the url for the summary page
+        assert query in run_summary_page.driver.current_url
 
-        # Check if the page query is in the summary page href
-        assert page_query in run_summary_page.cancel_button.get_attribute('href')
+        # Check if the query is in the summary page href
+        assert query in run_summary_page.cancel_button.get_attribute('href')
 
         # Click the cancel button to go back to the runs list
         run_summary_page.click_cancel_btn()
 
-        # Check if page query is still in the href
-        assert page_query in self.page.get_top_run().get_attribute('href')
+        # Check if query is still in the href
+        assert query in self.page.get_top_run().get_attribute('href')
 
-    def test_second_page_num_query(self):
-        """Test that the second page of runs passes the correct page number query."""
-        self.page.launch()
+    def test_each_query(self):
+        """Test that each potential query is maintained."""
+        for query in ("sort=run", "pagination=10", "filter=run", "page="):
+            self.page.launch()
+            self._test_page_query(query + "1" if query == "page=" else "", page=1)
+            self.page.click_page("Next Page")
+            self._test_page_query(query + "2" if query == "page=" else "", page=2)
 
-        # Click the 'Next Page' button
-        self.page.click_page("Next Page")
+    def test_pagination_filter(self):
+        """Test that changing the pagination filter also updates the URL query."""
+        for pagination in (10, 25, 50, 100, 250, 500):
+            self.page.launch()
+            self.page.update_items_per_page_option(pagination)
+            self.page.click_apply_filters()
+            self._test_page_query(f"{pagination=}", page=1)
 
-        # Test that the page number query works for the second page
-        self.test_page_num_query(page=2)
+    def test_sort_by_filter(self):
+        """Test that changing the sort by filter also updates the URL query."""
+        for sort in ("number", "date"):
+            self.page.launch()
+            self.page.update_sort_by_option(sort.title())
+            self.page.click_apply_filters()
+
+            if sort == "number":
+                sort = "run"
+
+            # {sort=!s} resolves to 'sort=<sort>'
+            self._test_page_query(f"{sort=!s}", page=1)

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
@@ -14,8 +14,10 @@ from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
 from autoreduce_frontend.selenium_tests.tests.base_tests import NavbarTestMixin, BaseTestCase, FooterTestMixin, \
     AccessibilityTestMixin
 
+from autoreduce_frontend.selenium_tests.utils import setup_archive
 
-class TestRunsListPage(NavbarTestMixin, BaseTestCase, FooterTestMixin, AccessibilityTestMixin):
+
+class TestRunsListPage(BaseTestCase):
     """
     Test cases for the InstrumentSummary page
     """
@@ -61,3 +63,34 @@ class TestRunsListPage(NavbarTestMixin, BaseTestCase, FooterTestMixin, Accessibi
         assert self.page.alert_message_text() == expected
 
         data_archive.delete()
+
+
+class TestNew(BaseTestCase):
+    """
+    Test cases for the InstrumentSummary page
+    """
+
+    fixtures = BaseTestCase.fixtures + ["eleven_runs"]
+
+    def setUp(self) -> None:
+        """
+        Sets up the InstrumentSummaryPage object
+        """
+        super().setUp()
+        self.instrument_name = "TestInstrument"
+        self.page = RunsListPage(self.driver, self.instrument_name)
+
+        #self.data_archive = setup_archive([self.instrument_name], 21, 21)
+        #self.data_archive.add_reduce_vars_script(self.instrument_name, 'standard_vars = {"variable": "somevalue"}')
+
+    def test_page_param_in_href(self):
+        """
+        Test that the page parameter is within the href
+        """
+        self.page.launch()
+        assert "page=1" in self.page.get_top_run().get_attribute('href')
+        run_summary_page = self.page.click_run(100000)
+        assert "page=1" in run_summary_page.driver.current_url
+        assert "page=1" in run_summary_page.cancel_button.get_attribute('href')
+        run_summary_page.click_cancel_btn()
+        assert "page=1" in self.page.get_top_run().get_attribute('href')

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
@@ -116,7 +116,7 @@ class TestParameters(BaseTestCase, NavbarTestMixin, FooterTestMixin, Accessibili
             self.page.launch()
             self.page.update_items_per_page_option(pagination)
             self.page.click_apply_filters()
-            self._test_page_query(f"{pagination=}", page=1)
+            self._test_page_query(f"pagination={pagination}", page=1)
 
     def test_sort_by_filter(self):
         """Test that changing the sort by filter also updates the URL query."""
@@ -129,4 +129,4 @@ class TestParameters(BaseTestCase, NavbarTestMixin, FooterTestMixin, Accessibili
                 sort = "run"
 
             # {sort=!s} resolves to 'sort=<sort>'
-            self._test_page_query(f"{sort=!s}", page=1)
+            self._test_page_query(f"sort={sort}", page=1)

--- a/autoreduce_frontend/selenium_tests/utils.py
+++ b/autoreduce_frontend/selenium_tests/utils.py
@@ -88,8 +88,7 @@ def setup_external_services(instrument_name: str, start_year: int,
 
 
 def setup_archive(instrument_name: str, start_year: int, end_year: int) -> DataArchive:
-    """
-    """
+    """Create a DataArchive."""
     data_archive = DataArchive([instrument_name], start_year, end_year)
     data_archive.create()
 

--- a/autoreduce_frontend/selenium_tests/utils.py
+++ b/autoreduce_frontend/selenium_tests/utils.py
@@ -77,8 +77,7 @@ def setup_external_services(instrument_name: str, start_year: int,
     :param end_year: End year for the archive
     :return: Tuple of external objects needed.
     """
-    data_archive = DataArchive([instrument_name], start_year, end_year)
-    data_archive.create()
+    data_archive = setup_archive(instrument_name, start_year, end_year)
     try:
         queue_client, listener = setup_connection()
     except ConnectionException as err:
@@ -86,3 +85,12 @@ def setup_external_services(instrument_name: str, start_year: int,
                            "ActiveMQ is running and started by `python setup.py start`") from err
 
     return data_archive, queue_client, listener
+
+
+def setup_archive(instrument_name: str, start_year: int, end_year: int) -> DataArchive:
+    """
+    """
+    data_archive = DataArchive([instrument_name], start_year, end_year)
+    data_archive.create()
+
+    return data_archive

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -94,8 +94,7 @@
                                         class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
                                 </div>
                                 <div id="instrument">
-                                    <strong>Instrument:</strong> <a
-                                        href="{% url 'runs:list' instrument=run.instrument.name %}">{{ run.instrument.name }}</a>
+                                    <strong>Instrument:</strong> {{ run.instrument.name }}
                                 </div>
                                 <div id="rb_number">
                                     <strong>RB Number:</strong> <a

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -234,7 +234,7 @@
         </div>
         <div class="row col-md-12 my-2">
             <div class="text-center">
-                <a href="{% url 'runs:list' run.instrument.name %}?page={{current_page}}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
+                <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
             </div>
         </div>
         {% endif %}

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -235,7 +235,7 @@
         </div>
         <div class="row col-md-12 my-2">
             <div class="text-center">
-                <a href="{% url 'runs:list' run.instrument.name %}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
+                <a href="{% url 'runs:list' run.instrument.name %}?page={{current_page}}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
             </div>
         </div>
         {% endif %}

--- a/autoreduce_frontend/templates/runs_list.html
+++ b/autoreduce_frontend/templates/runs_list.html
@@ -144,7 +144,7 @@
                         <div class="row run-row">
                     {% endif %}
                 <div class="col-md-5 col-sm-5 col-md-offset-1 col-xs-4"><a
-                        href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}"
+                        href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}?page={{ paginator.current_page_index }}"
                         {% if forloop.first %} id="top-run-number" {% endif %} class="run-num-links">{{ run.title }}</a></div>
                 <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}">
                     <strong>{{ run.status.value_verbose }}</strong></div>

--- a/autoreduce_frontend/templates/runs_list.html
+++ b/autoreduce_frontend/templates/runs_list.html
@@ -144,7 +144,7 @@
                         <div class="row run-row">
                     {% endif %}
                 <div class="col-md-5 col-sm-5 col-md-offset-1 col-xs-4"><a
-                        href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}?page={{ paginator.current_page_index }}"
+                        href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}?page={{ paginator.current_page_index }}&pagination={{ paginator.items_per_page }}&sort={{ paginator.page_type }}"
                         {% if forloop.first %} id="top-run-number" {% endif %} class="run-num-links">{{ run.title }}</a></div>
                 <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}">
                     <strong>{{ run.status.value_verbose }}</strong></div>


### PR DESCRIPTION
### Summary of work
Maintains URL queries after clicking on a run in the instrument runs page and after navigating back to the runs page by clicking the 'Back to <InstrumentName> runs' button.

### How to test your work
1. Checkout this branch and run the web app.
2. Navigate to http://127.0.0.1:8000/runs/LARMOR/
3. Change 'Items per page' to 50.
4. Navigate to the second page of runs.
5. Click the top run.
6. `?page=2&pagination=50&sort=run` should be visible in the URL.
7. Click the 'Back to LARMOUR runs' button.
8. The URL should still contain `?page=2&pagination=50&sort=run` and you should still be on the second page of runs with 50 runs listed.
9. Stop the web app and run the tests at `autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py`.

Fixes AR-1423

**Before merging ensure the release notes have been updated**