### PR TITLE
Updates setup.py to use new qp dev 7

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/admin.py
+++ b/autoreduce_frontend/autoreduce_webapp/admin.py
@@ -9,8 +9,8 @@ Initialise admin pages
 """
 from django.contrib import admin
 
-from autoreduce_db.reduction_viewer.models import (Instrument, Experiment, Status, ReductionRun, DataLocation,
-                                                   ReductionLocation, Setting, Notification)
+from autoreduce_db.reduction_viewer.models import (Instrument, Experiment, Status, ReductionRun, ReductionLocation,
+                                                   Setting, Notification)
 from autoreduce_db.instrument.models import InstrumentVariable, RunVariable
 from autoreduce_frontend.autoreduce_webapp.models import UserCache, InstrumentCache, ExperimentCache
 
@@ -22,7 +22,6 @@ admin.site.register(Instrument)
 admin.site.register(Experiment)
 admin.site.register(Status)
 admin.site.register(ReductionRun)
-admin.site.register(DataLocation)
 admin.site.register(ReductionLocation)
 admin.site.register(Setting)
 admin.site.register(Notification)

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/eleven_runs.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/eleven_runs.json
@@ -12,7 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -28,7 +29,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -44,7 +46,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -60,7 +63,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -76,7 +80,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -92,7 +97,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -108,7 +114,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -124,7 +131,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -140,7 +148,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -156,7 +165,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -172,23 +182,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
-        }
-    },
-    {
-        "pk": 2,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 2
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_mixed_vars.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_mixed_vars.json
@@ -12,15 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_plot.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_plot.json
@@ -13,7 +13,7 @@
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
             "instrument_id": 1,
-            "data_location": "/tmp"
+            "data_location": "/tmp/data.nxs"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_plot.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/one_run_plot.json
@@ -12,15 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp/data.nxs",
-            "reduction_run_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/pr_test.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/pr_test.json
@@ -15,15 +15,8 @@
             "experiment_id": 1,
             "instrument_id": 1,
             "started_by": -1,
-            "reduction_host": "test-host-123"
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/isis/NDXTestInstrument/Intsrument/data/cycle_21_1/TEST99999.nxs",
-            "reduction_run_id": 1
+            "reduction_host": "test-host-123",
+            "data_location": "/isis/NDXTestInstrument/Intsrument/data/cycle_21_1/TEST99999.nxs"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/run_with_multiple_variables.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/run_with_multiple_variables.json
@@ -16,7 +16,8 @@
             "instrument_id": 1,
             "started_by": -1,
             "reduction_host": "test-host-123",
-            "software_id": 1
+            "software_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -25,14 +26,6 @@
         "fields": {
             "name": "FakeSoftware",
             "version": "6"
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/run_with_one_variable.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/run_with_one_variable.json
@@ -1,4 +1,5 @@
-[{
+[
+    {
         "model": "reduction_viewer.reductionrun",
         "pk": 1,
         "fields": {
@@ -14,15 +15,8 @@
             "experiment_id": 1,
             "instrument_id": 1,
             "started_by": -1,
-            "reduction_host": "test-host-123"
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
+            "reduction_host": "test-host-123",
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/skipped_run.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/skipped_run.json
@@ -12,15 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/two_runs.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/two_runs.json
@@ -12,7 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -28,23 +29,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
-        }
-    },
-    {
-        "pk": 2,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 2
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/autoreduce_webapp/fixtures/two_runs_two_vars.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/two_runs_two_vars.json
@@ -12,7 +12,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {
@@ -28,23 +29,8 @@
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
-        "pk": 1,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 1
-        }
-    },
-    {
-        "pk": 2,
-        "model": "reduction_viewer.datalocation",
-        "fields": {
-            "file_path": "/tmp",
-            "reduction_run_id": 2
+            "instrument_id": 1,
+            "data_location": "/tmp"
         }
     },
     {

--- a/autoreduce_frontend/reduction_viewer/utils.py
+++ b/autoreduce_frontend/reduction_viewer/utils.py
@@ -77,7 +77,7 @@ class ReductionRunUtils:
                           run_number=most_recent_run.run_number,
                           instrument=most_recent_run.instrument.name,
                           rb_number=most_recent_run.experiment.reference_number,
-                          data=most_recent_run.data_location.first().file_path,
+                          data=most_recent_run.data_location,
                           reduction_script=script_text,
                           reduction_arguments=new_script_arguments,
                           run_version=most_recent_run.run_version,

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -288,7 +288,7 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
 
     if reduction_location:
         try:
-            plot_handler = PlotHandler(data_filepath=run.data_location.first().file_path,
+            plot_handler = PlotHandler(data_filepath=run.data_location,
                                        server_dir=reduction_location,
                                        rb_number=rb_number)
             local_plot_locs, server_plot_locs = plot_handler.get_plot_file()
@@ -407,9 +407,7 @@ def experiment_summary(request, reference_number=None):
         reduced_data = []
         started_by = []
         for run in runs:
-            for location in run.data_location.all():
-                if location not in data:
-                    data.append(location)
+            data.append(run.data_location)
             for location in run.reduction_location.all():
                 if location not in reduced_data:
                     reduced_data.append(location)

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_plots.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_plots.py
@@ -35,28 +35,28 @@ class TestRunSummaryPagePlots(BaseTestCase):
         self.page = RunSummaryPage(self.driver, self.instrument_name, 99999, 0)
         self.run = ReductionRun.objects.first()
 
-    # def test_plot_files_png(self):
-    #     """
-    #     Test: PNG plot files are fetched and shown
-    #     """
-    #     # the plot files are expected to be in the reduction location, so we write them there for the test to work
-    #     plot_files = [
-    #         tempfile.NamedTemporaryFile(prefix="data_",
-    #                                     suffix=".png",
-    #                                     dir=self.run.reduction_location.first().file_path),
-    #         tempfile.NamedTemporaryFile(prefix="data_",
-    #                                     suffix=".png",
-    #                                     dir=self.run.reduction_location.first().file_path)
-    #     ]
-    #     self.page.launch()
+    def test_plot_files_png(self):
+        """
+        Test: PNG plot files are fetched and shown
+        """
+        # the plot files are expected to be in the reduction location, so we write them there for the test to work
+        plot_files = [
+            tempfile.NamedTemporaryFile(prefix="data_",
+                                        suffix=".png",
+                                        dir=self.run.reduction_location.first().file_path),
+            tempfile.NamedTemporaryFile(prefix="data_",
+                                        suffix=".png",
+                                        dir=self.run.reduction_location.first().file_path)
+        ]
+        self.page.launch()
 
-    #     # 1 is the logo, the other 2 are the plots
-    #     images = self.page.images()
-    #     assert len(images) == 3
-    #     for img in images[1:]:
-    #         alt_text = img.get_attribute("alt")
-    #         assert "Plot image stored at" in alt_text
-    #         assert any(os.path.basename(f.name) in alt_text for f in plot_files)
+        # 1 is the logo, the other 2 are the plots
+        images = self.page.images()
+        assert len(images) == 3
+        for img in images[1:]:
+            alt_text = img.get_attribute("alt")
+            assert "Plot image stored at" in alt_text
+            assert any(os.path.basename(f.name) in alt_text for f in plot_files)
 
     def test_plot_files_json(self):
         """
@@ -82,32 +82,32 @@ class TestRunSummaryPagePlots(BaseTestCase):
         for plot in plots:
             assert any(plot.get_attribute("id") in file.name for file in plot_files)
 
-    # def test_plot_files_mix(self):
-    #     """Test that both static and interactive plots are rendered"""
-    #     plot_files = [
-    #         tempfile.NamedTemporaryFile(prefix="data_",
-    #                                     suffix=".png",
-    #                                     dir=self.run.reduction_location.first().file_path),
-    #         tempfile.NamedTemporaryFile('w',
-    #                                     prefix="data_",
-    #                                     suffix=".json",
-    #                                     dir=self.run.reduction_location.first().file_path)
-    #     ]
-    #     # write the interactive plot data
-    #     plot_files[1].write("""{"data": [{"type": "bar","x": [1,2,3],"y": [1,3,2]}]}""")
-    #     plot_files[1].flush()
+    def test_plot_files_mix(self):
+        """Test that both static and interactive plots are rendered"""
+        plot_files = [
+            tempfile.NamedTemporaryFile(prefix="data_",
+                                        suffix=".png",
+                                        dir=self.run.reduction_location.first().file_path),
+            tempfile.NamedTemporaryFile('w',
+                                        prefix="data_",
+                                        suffix=".json",
+                                        dir=self.run.reduction_location.first().file_path)
+        ]
+        # write the interactive plot data
+        plot_files[1].write("""{"data": [{"type": "bar","x": [1,2,3],"y": [1,3,2]}]}""")
+        plot_files[1].flush()
 
-    #     self.page.launch()
+        self.page.launch()
 
-    #     images = self.page.images()
-    #     # 1 is the logo, the other is the static plot
-    #     assert len(images) == 2
+        images = self.page.images()
+        # 1 is the logo, the other is the static plot
+        assert len(images) == 2
 
-    #     img = images[1]
-    #     alt_text = img.get_attribute("alt")
-    #     assert "Plot image stored at" in alt_text
-    #     assert any(os.path.basename(f.name) in alt_text for f in plot_files)
+        img = images[1]
+        alt_text = img.get_attribute("alt")
+        assert "Plot image stored at" in alt_text
+        assert any(os.path.basename(f.name) in alt_text for f in plot_files)
 
-    #     plots = self.page.plotly_plots()
-    #     assert len(plots) == 1
-    #     assert plots[0].get_attribute("id") in plot_files[1].name
+        plots = self.page.plotly_plots()
+        assert len(plots) == 1
+        assert plots[0].get_attribute("id") in plot_files[1].name

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_plots.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_plots.py
@@ -35,28 +35,28 @@ class TestRunSummaryPagePlots(BaseTestCase):
         self.page = RunSummaryPage(self.driver, self.instrument_name, 99999, 0)
         self.run = ReductionRun.objects.first()
 
-    def test_plot_files_png(self):
-        """
-        Test: PNG plot files are fetched and shown
-        """
-        # the plot files are expected to be in the reduction location, so we write them there for the test to work
-        plot_files = [
-            tempfile.NamedTemporaryFile(prefix="data_",
-                                        suffix=".png",
-                                        dir=self.run.reduction_location.first().file_path),
-            tempfile.NamedTemporaryFile(prefix="data_",
-                                        suffix=".png",
-                                        dir=self.run.reduction_location.first().file_path)
-        ]
-        self.page.launch()
+    # def test_plot_files_png(self):
+    #     """
+    #     Test: PNG plot files are fetched and shown
+    #     """
+    #     # the plot files are expected to be in the reduction location, so we write them there for the test to work
+    #     plot_files = [
+    #         tempfile.NamedTemporaryFile(prefix="data_",
+    #                                     suffix=".png",
+    #                                     dir=self.run.reduction_location.first().file_path),
+    #         tempfile.NamedTemporaryFile(prefix="data_",
+    #                                     suffix=".png",
+    #                                     dir=self.run.reduction_location.first().file_path)
+    #     ]
+    #     self.page.launch()
 
-        # 1 is the logo, the other 2 are the plots
-        images = self.page.images()
-        assert len(images) == 3
-        for img in images[1:]:
-            alt_text = img.get_attribute("alt")
-            assert "Plot image stored at" in alt_text
-            assert any(os.path.basename(f.name) in alt_text for f in plot_files)
+    #     # 1 is the logo, the other 2 are the plots
+    #     images = self.page.images()
+    #     assert len(images) == 3
+    #     for img in images[1:]:
+    #         alt_text = img.get_attribute("alt")
+    #         assert "Plot image stored at" in alt_text
+    #         assert any(os.path.basename(f.name) in alt_text for f in plot_files)
 
     def test_plot_files_json(self):
         """
@@ -82,32 +82,32 @@ class TestRunSummaryPagePlots(BaseTestCase):
         for plot in plots:
             assert any(plot.get_attribute("id") in file.name for file in plot_files)
 
-    def test_plot_files_mix(self):
-        """Test that both static and interactive plots are rendered"""
-        plot_files = [
-            tempfile.NamedTemporaryFile(prefix="data_",
-                                        suffix=".png",
-                                        dir=self.run.reduction_location.first().file_path),
-            tempfile.NamedTemporaryFile('w',
-                                        prefix="data_",
-                                        suffix=".json",
-                                        dir=self.run.reduction_location.first().file_path)
-        ]
-        # write the interactive plot data
-        plot_files[1].write("""{"data": [{"type": "bar","x": [1,2,3],"y": [1,3,2]}]}""")
-        plot_files[1].flush()
+    # def test_plot_files_mix(self):
+    #     """Test that both static and interactive plots are rendered"""
+    #     plot_files = [
+    #         tempfile.NamedTemporaryFile(prefix="data_",
+    #                                     suffix=".png",
+    #                                     dir=self.run.reduction_location.first().file_path),
+    #         tempfile.NamedTemporaryFile('w',
+    #                                     prefix="data_",
+    #                                     suffix=".json",
+    #                                     dir=self.run.reduction_location.first().file_path)
+    #     ]
+    #     # write the interactive plot data
+    #     plot_files[1].write("""{"data": [{"type": "bar","x": [1,2,3],"y": [1,3,2]}]}""")
+    #     plot_files[1].flush()
 
-        self.page.launch()
+    #     self.page.launch()
 
-        images = self.page.images()
-        # 1 is the logo, the other is the static plot
-        assert len(images) == 2
+    #     images = self.page.images()
+    #     # 1 is the logo, the other is the static plot
+    #     assert len(images) == 2
 
-        img = images[1]
-        alt_text = img.get_attribute("alt")
-        assert "Plot image stored at" in alt_text
-        assert any(os.path.basename(f.name) in alt_text for f in plot_files)
+    #     img = images[1]
+    #     alt_text = img.get_attribute("alt")
+    #     assert "Plot image stored at" in alt_text
+    #     assert any(os.path.basename(f.name) in alt_text for f in plot_files)
 
-        plots = self.page.plotly_plots()
-        assert len(plots) == 1
-        assert plots[0].get_attribute("id") in plot_files[1].name
+    #     plots = self.page.plotly_plots()
+    #     assert len(plots) == 1
+    #     assert plots[0].get_attribute("id") in plot_files[1].name

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -165,10 +165,8 @@
                             <div class="col-md-6">
                                 <div class="file-path">
                                     <strong>Data:</strong>
-                                    {% if run.data_location.all %}
-                                        {% for location in run.data_location.all %}
-                                            {{ location.file_path }}<br/>
-                                        {% endfor %}
+                                    {% if run.data_location %}
+                                        {{ run.data_location }}<br/>
                                     {% else %}
                                         <em>No data found</em>
                                     {% endif %}

--- a/container/webapp.D
+++ b/container/webapp.D
@@ -4,6 +4,6 @@ ADD ./setup.py /autoreduce-frontend/setup.py
 
 # add --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple for packages in test.pypi.org
 # also when updating the version here make sure it matches the one in setup.py
-RUN python3 -m pip install --no-cache-dir gunicorn autoreduce-frontend==22.0.0.dev5
+RUN python3 -m pip install --no-cache-dir gunicorn autoreduce-frontend==22.0.0.dev6
 
 CMD autoreduce-webapp-manage runserver 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # Additional packages that will be installed in a test environment
 
+axe-selenium-python==2.1.6
 django-debug-toolbar==3.2.1
+selenium==3.141.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,3 @@
-# Test Env. Requirements
+# Additional packages that will be installed in a test environment
 
-axe-selenium-python==2.1.6
-coveralls==3.1.0
 django-debug-toolbar==3.2.1
-parameterized==0.8.1
-pylint==2.8.3
-pylint-django==2.4.4
-pytest==6.2.4
-pytest-cov==2.12.1
-pytest-django==4.4.0
-selenium==3.141.0
-vulture==2.3
-yapf==0.31.0

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ print(data_files)
 
 setup(
     name=PACKAGE_NAME,
-    version="22.0.0.dev6",  # when updating the version here make sure to also update webapp.D
+    version="22.0.0.dev7",  # when updating the version here make sure to also update webapp.D
     description="The frontend of the ISIS Autoreduction service",
     author="ISIS Autoreduction Team",
     url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
     install_requires=[
-        "autoreduce_qp==22.0.0.dev7", "Django==3.2.6", "django_extensions==3.1.3", "django-user-agents==0.4.0",
+        "autoreduce_qp==22.0.0.dev8", "Django==3.2.6", "django_extensions==3.1.3", "django-user-agents==0.4.0",
         "djangorestframework==3.12.4"
     ],
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ print(data_files)
 
 setup(
     name=PACKAGE_NAME,
-    version="22.0.0.dev5",  # when updating the version here make sure to also update webapp.D
+    version="22.0.0.dev6",  # when updating the version here make sure to also update webapp.D
     description="The frontend of the ISIS Autoreduction service",
     author="ISIS Autoreduction Team",
     url="https://github.com/ISISScientificComputing/autoreduce-frontend/",
     install_requires=[
-        "autoreduce_qp==22.0.0.dev5", "Django==3.2.4", "django_extensions==3.1.3", "django-user-agents==0.4.0",
+        "autoreduce_qp==22.0.0.dev7", "Django==3.2.6", "django_extensions==3.1.3", "django-user-agents==0.4.0",
         "djangorestframework==3.12.4"
     ],
     packages=find_packages(),


### PR DESCRIPTION
### Summary of work
Updates setup.py to use `autoreduce_qp==22.0.0.dev7`, which has the DB DataLocation changes. Updates calls and fixtures that use the old DataLocation model.

Removes duplicated packages in requirements.txt in favour of using the common deps at https://github.com/ISISScientificComputing/autoreduce-actions/blob/master/requirements.txt

### How to test your work

- Install new package versions for this setup.py
- Migrate the DB
- Run the webapp
- Check that data location is shown correctly in run summary, e.g. 
![image](https://user-images.githubusercontent.com/9135965/129187813-ea23db2f-0b18-4d31-98f6-2517fdeabe18.png)


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes https://autoreduce.atlassian.net/browse/AR-1512

**Before merging ensure the release notes have been updated**