### PR TITLE
1395 buttons for no variables rendered ar 1395

### DIFF
--- a/autoreduce_frontend/instrument/views/variables.py
+++ b/autoreduce_frontend/instrument/views/variables.py
@@ -107,12 +107,19 @@ def summarize_variables(request, instrument, last_run_object):
 @check_permissions
 def delete_instrument_variables(request, instrument=None, start=0, end=0, experiment_reference=None):
     """
-    Handles request for deleting instrument variables
+    Handle request for deleting instrument variables.
 
-    :param instrument: Name of the instrument for which variables are being deleted
-    :param start: The start run from which variables are being deleted
-    :param end: Used to limit how many variables get deleted, otherwise a delete would wipe ALL variables > start
-    :param experiment_reference: If provided - use the experiment reference to delete variables instead of start_run
+    Args:
+        instrument: Name of the instrument for which variables are being
+        deleted.
+
+        start: Run from which variables are being deleted.
+
+        end: Limit of how many variables get deleted, otherwise a delete would
+        wipe ALL variables > start.
+
+        experiment_reference: If provided - use the experiment reference to
+        delete variables instead of start_run.
     """
 
     # We "save" an empty list to delete the previous variables.
@@ -132,9 +139,7 @@ def delete_instrument_variables(request, instrument=None, start=0, end=0, experi
 @check_permissions
 @render_with('variables_summary.html')
 def instrument_variables_summary(request, instrument):
-    """
-    Handles request to view instrument variables
-    """
+    """Handle request to view instrument variables."""
     instrument = Instrument.objects.get(name=instrument)
     context_dictionary = {'instrument': instrument, 'last_instrument_run': instrument.reduction_runs.last()}
     return context_dictionary
@@ -150,14 +155,15 @@ def current_default_variables(request, instrument=None):
         current_variables = VariableUtils.get_default_variables(instrument)
     except (FileNotFoundError, ImportError, SyntaxError) as err:
         return {"message": str(err)}
+
     standard_vars = current_variables["standard_vars"]
     advanced_vars = current_variables["advanced_vars"]
-
     context_dictionary = {
         'instrument': instrument,
         'standard_variables': standard_vars,
         'advanced_variables': advanced_vars,
     }
+
     return context_dictionary
 
 
@@ -181,7 +187,6 @@ def render_run_variables(request, instrument_name, run_number, run_version=0):
 
     final_standard = _combine_dicts(standard_vars, default_standard_variables)
     final_advanced = _combine_dicts(advanced_vars, default_advanced_variables)
-
     context_dictionary = {
         'run_number': run_number,
         'run_version': run_version,
@@ -189,6 +194,7 @@ def render_run_variables(request, instrument_name, run_number, run_version=0):
         'advanced_variables': final_advanced,
         'instrument': reduction_run.instrument,
     }
+
     return render(request, 'snippets/run_variables.html', context_dictionary)
 
 
@@ -206,4 +212,5 @@ def _combine_dicts(current: dict, default: dict):
     final = {}
     for name, var in current.items():
         final[name] = {"current": var, "default": default.get(name, None)}
+
     return final

--- a/autoreduce_frontend/instrument/views/variables.py
+++ b/autoreduce_frontend/instrument/views/variables.py
@@ -5,32 +5,27 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
 """
-View functions for displaying Variable data
-This imports into another view, thus no middleware
+View functions for displaying Variable data. This imports into another view,
+thus no middleware.
 """
+# pylint:disable=too-many-locals,no-member,unused-argument
 import logging
-import os
 
 from django.shortcuts import redirect, render
+
 from autoreduce_db.instrument.models import InstrumentVariable
 from autoreduce_db.reduction_viewer.models import Instrument, ReductionRun
 from autoreduce_qp.queue_processor.variable_utils import VariableUtils
-
-from autoreduce_frontend.autoreduce_webapp.view_utils import (check_permissions, login_and_uows_valid, render_with)
+from autoreduce_frontend.autoreduce_webapp.view_utils import check_permissions, login_and_uows_valid, render_with
 from autoreduce_frontend.reduction_viewer.utils import ReductionRunUtils
 
 LOGGER = logging.getLogger(__package__)
 
 
-# pylint:disable=too-many-locals
 def summarize_variables(request, instrument, last_run_object):
-    """
-    Handles view request for the instrument summary page
-    """
-    # pylint:disable=no-member
+    """Handle view request for the instrument summary page."""
     instrument = Instrument.objects.get(name=instrument)
 
-    # pylint:disable=invalid-name
     current_variables = [runvar.variable.instrumentvariable for runvar in last_run_object.run_variables.all()]
 
     upcoming_variables_by_run = InstrumentVariable.objects.filter(start_run__gt=last_run_object.run_number,
@@ -40,7 +35,7 @@ def summarize_variables(request, instrument, last_run_object):
 
     # There's a known issue with inaccurate display of tracks script:
     # https://github.com/ISISScientificComputing/autoreduce/issues/1187
-    # Creates a nested dictionary for by-run
+    # creates a nested dictionary for by-run
     upcoming_variables_by_run_dict = {}
     for variable in upcoming_variables_by_run:
         if variable.start_run not in upcoming_variables_by_run_dict:
@@ -108,7 +103,6 @@ def summarize_variables(request, instrument, last_run_object):
     return render(request, 'snippets/instrument_summary_variables.html', context_dictionary)
 
 
-# pylint:disable=unused-argument
 @login_and_uows_valid
 @check_permissions
 def delete_instrument_variables(request, instrument=None, start=0, end=0, experiment_reference=None):
@@ -137,7 +131,6 @@ def delete_instrument_variables(request, instrument=None, start=0, end=0, experi
 @login_and_uows_valid
 @check_permissions
 @render_with('variables_summary.html')
-# pylint:disable=no-member
 def instrument_variables_summary(request, instrument):
     """
     Handles request to view instrument variables
@@ -151,9 +144,7 @@ def instrument_variables_summary(request, instrument):
 @check_permissions
 @render_with('snippets/variables/form.html')
 def current_default_variables(request, instrument=None):
-    """
-    Handles request to view default variables
-    """
+    """Handle request to view default variables."""
 
     try:
         current_variables = VariableUtils.get_default_variables(instrument)
@@ -171,10 +162,7 @@ def current_default_variables(request, instrument=None):
 
 
 def render_run_variables(request, instrument_name, run_number, run_version=0):
-    """
-    Handles request to view the summary of a run
-    """
-    # pylint:disable=no-member
+    """Handle request to view the summary of a run."""
     reduction_run = ReductionRun.objects.get(instrument__name=instrument_name,
                                              run_number=run_number,
                                              run_version=run_version)
@@ -206,10 +194,11 @@ def render_run_variables(request, instrument_name, run_number, run_version=0):
 
 def _combine_dicts(current: dict, default: dict):
     """
-    Combines the current and default variable dictionaries, into a single dictionary
-    which can be more easily rendered into the webapp.
+    Combine the current and default variable dictionaries, into a single
+    dictionary which can be more easily rendered into the webapp.
 
-    If no current variables are provided, it returns the default as both current and default.
+    If no current variables are provided, return the default as both current and
+    default.
     """
     if not current:
         current = default.copy()

--- a/autoreduce_frontend/instrument/views/variables.py
+++ b/autoreduce_frontend/instrument/views/variables.py
@@ -182,6 +182,7 @@ def render_run_variables(request, instrument_name, run_number, run_version=0):
         default_standard_variables = default_variables["standard_vars"]
         default_advanced_variables = default_variables["advanced_vars"]
     except (FileNotFoundError, ImportError, SyntaxError):
+        default_variables = {}
         default_standard_variables = {}
         default_advanced_variables = {}
 
@@ -190,6 +191,7 @@ def render_run_variables(request, instrument_name, run_number, run_version=0):
     context_dictionary = {
         'run_number': run_number,
         'run_version': run_version,
+        'has_reduce_vars': bool(default_variables),
         'standard_variables': final_standard,
         'advanced_variables': final_advanced,
         'instrument': reduction_run.instrument,

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -251,12 +251,7 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
             reduction_location = reduction_location.replace('\\', '/')
 
         data_analysis_link_url = make_data_analysis_url(reduction_location) if reduction_location else ""
-
         rb_number = run.experiment.reference_number
-        try:
-            current_variables = VariableUtils.get_default_variables(run.instrument.name)
-        except (FileNotFoundError, ImportError, SyntaxError):
-            current_variables = {}
 
         context_dictionary = {
             'run': run,
@@ -268,7 +263,6 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
             'history': history,
             'reduction_location': reduction_location,
             'started_by': started_by,
-            'has_reduce_vars': bool(current_variables),
             'has_run_variables': bool(run.run_variables.count()),
             'data_analysis_link_url': data_analysis_link_url,
             'current_page': int(request.GET.get('page', 1)),

--- a/autoreduce_frontend/reduction_viewer/views.py
+++ b/autoreduce_frontend/reduction_viewer/views.py
@@ -115,7 +115,7 @@ def overview(_):
     Render the overview landing page (redirect from /index).
 
     Note:
-      _ is replacing the passed in request parameter.
+        _ is replacing the passed in request parameter.
     """
     context_dictionary = {}
     instruments = Instrument.objects.values_list("name", flat=True)
@@ -140,10 +140,10 @@ def run_queue(request):
         try:
             with ICATCache(AUTH='uows', SESSION={'sessionid': request.session['sessionid']}) as icat:
                 pending_jobs = filter(lambda job: job.experiment.reference_number in icat.get_associated_experiments(
-                    int(request.user.username)), pending_jobs)  # check RB numbers
+                    int(request.user.username)), pending_jobs)  # Check RB numbers
                 pending_jobs = filter(
                     lambda job: job.instrument.name in icat.get_owned_instruments(int(request.user.username)),
-                    pending_jobs)  # check instrument
+                    pending_jobs)  # Check instrument
         except ICATConnectionException as excep:
             return render_error(request, str(excep))
     # Initialise list to contain the names of user/team that started runs
@@ -469,7 +469,7 @@ def help(_):
     Render help page.
 
     Note:
-      _ is replacing the passed in request parameter.
+        _ is replacing the passed in request parameter.
     """
     return {}
 
@@ -481,7 +481,7 @@ def accessibility_statement(_):
     Render accessibility statement page.
 
     Note:
-      _ is replacing the passed in request parameter.
+        _ is replacing the passed in request parameter.
     """
     return {}
 
@@ -493,7 +493,7 @@ def graph_home(_):
     Render graph page.
 
     Note:
-      _ is replacing the passed in request parameter.
+        _ is replacing the passed in request parameter.
     """
     instruments = Instrument.objects.all()
     context_dictionary = {'instruments': instruments}
@@ -548,7 +548,7 @@ def stats(_):
     Render run statistics page.
 
     Note:
-      _ is replacing the passed in request parameter.
+        _ is replacing the passed in request parameter.
     """
     statuses = []
     for status in Status.objects.all():
@@ -573,17 +573,17 @@ def started_by_id_to_name(started_by_id=None):
     Return the name of the user or team that submitted an autoreduction run.
 
     Args:
-      started_by_id: The ID of the user who started the run, or a control code
-      if not started by a user.
+        started_by_id: The ID of the user who started the run, or a control code
+        if not started by a user.
 
     Returns:
-      If started by a valid user, return '[forename] [surname]'.
+        If started by a valid user, return '[forename] [surname]'.
 
-      If started automatically, return 'Autoreducton service'.
+        If started automatically, return 'Autoreducton service'.
 
-      If started manually, return 'Development team'.
+        If started manually, return 'Development team'.
 
-      Otherwise, return None.
+        Otherwise, return None.
     """
     if started_by_id is None or started_by_id < -1:
         return None

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -20,9 +20,7 @@ from autoreduce_frontend.selenium_tests.pages.page import Page
 
 
 class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
-    """
-    Page model class for run summary page
-    """
+    """Page model class for run summary page."""
     def __init__(self, driver, instrument, run_number, version):
         super().__init__(driver)
         self.instrument = instrument
@@ -30,10 +28,7 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         self.version = version
 
     def url_path(self) -> str:
-        """
-        Return the current URL of the page.
-        :return: (str) the url path
-        """
+        """Return the current URL of the page."""
         return reverse("runs:summary",
                        kwargs={
                            "instrument_name": self.instrument,
@@ -43,94 +38,70 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
 
     @property
     def reduction_job_panel(self) -> WebElement:
-        """Finds the run summary panel on the page."""
+        """Return the run summary panel on the page."""
         return self.driver.find_element_by_id("reduction_job_panel")
 
     @property
     def rerun_form(self) -> WebElement:
-        """Finds and returns the rerun form on the page"""
+        """Return the rerun form on the page."""
         return self.driver.find_element_by_id("rerun_form")
 
     @property
     def toggle_button(self) -> WebElement:
-        """
-        Finds and returns the toggle button for toggling the form on the page.
-        """
+        """Return the toggle button for toggling the form on the page."""
         return self.driver.find_element_by_id("toggle_form")
 
     @property
     def reset_to_initial_values(self) -> WebElement:
-        """
-        Finds and returns the "Reset to original script and values" button
-        """
+        """Returns the "Reset to original script and values" button."""
         return self.driver.find_element_by_id("resetValues")
 
     @property
     def reset_to_current_values(self) -> WebElement:
         """
-        Finds and returns the "Reset to values in the current reduce_vars script" button
-        """
+        Return the "Reset to values in the current reduce_vars script"
+        button."""
         return self.driver.find_element_by_id("currentScript")
 
     @property
     def warning_message(self) -> WebElement:
-        """
-        Finds and returns the "warning_message" box
-        """
+        """Return the "warning_message" box."""
         return self.driver.find_element_by_id("warning_message")
 
     def run_description_text(self) -> str:
-        """
-        Finds and returns the text of the run_description field
-        """
+        """Find and returns the text of the run_description field."""
         return self.driver.find_element_by_id("run_description").text
 
     def started_by_text(self) -> str:
-        """
-        Finds and returns the text of the started_by field
-        """
+        """Return the text of the started_by field."""
         return self.driver.find_element_by_id("started_by").text
 
     def status_text(self) -> str:
-        """
-        Finds and returns the text of the status field
-        """
+        """Return the text of the status field."""
         return self.driver.find_element_by_id("status").text
 
     def instrument_text(self) -> str:
-        """
-        Finds and returns the text of the instrument field
-        """
+        """Return the text of the instrument field."""
         return self.driver.find_element_by_id("instrument").text
 
     def rb_number_text(self) -> str:
-        """
-        Finds and returns the text of the rb_number field
-        """
+        """Return the text of the rb_number field."""
         return self.driver.find_element_by_id("rb_number").text
 
     def last_updated_text(self) -> str:
-        """
-        Finds and returns the text of the last_updated field
-        """
+        """Return the text of the last_updated field."""
         return self.driver.find_element_by_id("last_updated").text
 
     def reduction_host_text(self) -> WebElement:
-        """
-        Returns the reduction host text
-        """
+        """Return the reduction host text."""
         return self.driver.find_element_by_id("reduction_host").text
 
     def images(self) -> List[WebElement]:
-        """
-        Returns all image elements on the page.
-        """
+        """Return all image elements on the page."""
         return self.driver.find_elements_by_tag_name("img")
 
     def plotly_plots(self) -> List[WebElement]:
-        """
-        Returns all image elements on the page.
-        """
+        """Return all image elements on the page."""
         return self.driver.find_elements_by_class_name("js-plotly-plot")
 
     def _do_cancel_btn(self, url):

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_no_archive.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_no_archive.py
@@ -5,11 +5,10 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
 """Selenium tests for the runs summary page."""
-
-from autoreduce_db.reduction_viewer.models import ReductionRun
+from selenium.webdriver.support.ui import WebDriverWait
 from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
-from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, FooterTestMixin, NavbarTestMixin, \
-    AccessibilityTestMixin
+from autoreduce_frontend.selenium_tests.tests.base_tests import (AccessibilityTestMixin, BaseTestCase, FooterTestMixin,
+                                                                 NavbarTestMixin)
 
 
 # pylint:disable=no-member
@@ -30,25 +29,10 @@ class TestRunSummaryPageNoArchive(NavbarTestMixin, BaseTestCase, FooterTestMixin
 
     def test_opening_run_summary_without_reduce_vars(self):
         """
-        Test that opening the run summary without a reduce_vars present for the
-        instrument will not show the "Reset to current" buttons as there are no
-        current values.
+        Test that opening the run summary without a reduce_vars.py file present
+        for the instrument will not show the "Reset to current" buttons as there
+        are no current values.
         """
-        # the reset to current values should not be visible
-        assert self.page.warning_message.is_displayed()
-        assert self.page.warning_message.text == ("The reduce_vars.py script is missing for this instrument."
-                                                  " Please create it before being able to submit re-runs.")
-
-    def test_opening_run_summary_without_run_variables(self):
-        """
-        Test that opening the run summary without run variables for the
-        instrument will not show the "Reset to current" buttons as there is no
-        current values.
-        """
-        # Delete the variables, and re-open the page
-        ReductionRun.objects.get(pk=1).run_variables.all().delete()
-        self.page.launch()
-        # the reset to current values should not be visible
-        assert self.page.warning_message.is_displayed()
-        assert self.page.warning_message.text == "No variables found for this run."
-        assert self.page.run_description_text() == "Run description: This is the test run_description"
+        self.page.toggle_button.click()
+        assert WebDriverWait(self.driver, 10).until(lambda _: self.page.warning_message.is_displayed())
+        assert "The reduce_vars.py script is missing" in self.page.warning_message.text

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_no_archive.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_no_archive.py
@@ -4,12 +4,9 @@
 # Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
-"""
-Selenium tests for the runs summary page
-"""
+"""Selenium tests for the runs summary page."""
 
 from autoreduce_db.reduction_viewer.models import ReductionRun
-
 from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
 from autoreduce_frontend.selenium_tests.tests.base_tests import BaseTestCase, FooterTestMixin, NavbarTestMixin, \
     AccessibilityTestMixin
@@ -21,20 +18,21 @@ class TestRunSummaryPageNoArchive(NavbarTestMixin, BaseTestCase, FooterTestMixin
 
     @classmethod
     def setUpClass(cls):
-        """Set the instrument for all test cases"""
+        """Set the instrument for all test cases."""
         super().setUpClass()
         cls.instrument_name = "TestInstrument"
 
     def setUp(self) -> None:
-        """Set up RunSummaryPage before each test case"""
+        """Set up RunSummaryPage before each test case."""
         super().setUp()
         self.page = RunSummaryPage(self.driver, self.instrument_name, 99999, 0)
         self.page.launch()
 
     def test_opening_run_summary_without_reduce_vars(self):
         """
-        Test that opening the run summary without a reduce_vars present for the instrument
-        will not show the "Reset to current" buttons as there is no current values!
+        Test that opening the run summary without a reduce_vars present for the
+        instrument will not show the "Reset to current" buttons as there are no
+        current values.
         """
         # the reset to current values should not be visible
         assert self.page.warning_message.is_displayed()
@@ -43,8 +41,9 @@ class TestRunSummaryPageNoArchive(NavbarTestMixin, BaseTestCase, FooterTestMixin
 
     def test_opening_run_summary_without_run_variables(self):
         """
-        Test that opening the run summary without a reduce_vars present for the instrument
-        will not show the "Reset to current" buttons as there is no current values!
+        Test that opening the run summary without run variables for the
+        instrument will not show the "Reset to current" buttons as there is no
+        current values.
         """
         # Delete the variables, and re-open the page
         ReductionRun.objects.get(pk=1).run_variables.all().delete()

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -9,14 +9,13 @@
 {% load get_run_navigation_queries %}
 
 {% block body %}
-    {% comment %} only pull in plotly if there are interactive plots {% endcomment %}
+    <!-- Only pull in plotly if there are interactive plots -->
     {% if interactive_plots %}
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+        <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     {% endif %}
+
     {% if not run %}
-        <div class="text-center col-md-6 col-md-offset-3 well well-small">
-            Reduction run not found or error encountered: {{ message }}.
-        </div>
+        <div class="text-center col-md-6 col-md-offset-3 well well-small">Reduction run not found or error encountered: {{ message }}.</div>
     {% else %}
         <title>Reduction Job #{{ run.title }}</title>
         <div class="row">
@@ -38,7 +37,7 @@
             </div>
         {% else %}
             {% if static_plots %}
-            <div class="row plot-container">
+                <div class="row plot-container">
                 {% for plot_file in static_plots %}
                     {% if static_plots|length == 1 %}
                         <img class="center-block" src="{{ plot_file }}" alt="Plot image stored at {{ plot_file }}">
@@ -46,21 +45,22 @@
                         <img class="col-md-6" src="{{ plot_file }}" alt="Plot image stored at {{ plot_file }}">
                     {% endif %}
                 {% endfor %}
-            </div>
+                </div>
             {% endif %}
             {% if interactive_plots %}
-             <div class="row plot-container">
-                {% for name, data in interactive_plots.items %}
-                    <div id="{{ name }}"></div>
-                    <script>
-                        var data = JSON.parse('{{ data|escapejs }}');
-                        var elem = document.getElementById("{{ name }}");
-                        Plotly.newPlot(elem, data);
-                    </script>
-                {% endfor %}
-            </div>
+                <div class="row plot-container">
+                    {% for name, data in interactive_plots.items %}
+                        <div id="{{ name }}"></div>
+                        <script>
+                            var data = JSON.parse('{{ data|escapejs }}');
+                            var elem = document.getElementById("{{ name }}");
+                            Plotly.newPlot(elem, data);
+                        </script>
+                    {% endfor %}
+                </div>
             {% endif %}
         {% endif %}
+
         {% if run.message %}
             {% if 'Skipped' in run.message %}
                 <div class="alert alert-{% replace run.status.value_verbose 'Skipped' 'info' %} word-wrap" role="alert">
@@ -74,6 +74,7 @@
                 </div>
             {% endif %}
         {% endif %}
+
         <div class="row" id="reduction_job_panel">
             <div class="col-md-8 col-md-offset-2">
                 <div class="panel panel-primary panel-small panel-2-column">
@@ -81,30 +82,35 @@
                         <div class="row">
                             <div class="col-md-6">
                                 <div id="run_description">
-                                {% if run.run_description %}
-                                    <strong>Run description: </strong> {{ run.run_description }}
+                                    {% if run.run_description %}
+                                        <strong>Run description: </strong> {{ run.run_description }}
                                     {% endif %}
                                 </div>
+
                                 <div id="started_by">
-                                {% if started_by is not null %}
-                                    <strong>Started by:</strong> {{ started_by }}
+                                    {% if started_by is not null %}
+                                        <strong>Started by:</strong> {{ started_by }}
                                     {% endif %}
                                 </div>
+
                                 <div id="status">
-                                    <strong>Status:</strong> <strong
-                                        class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
+                                    <strong>Status:</strong> <strong class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
                                 </div>
+
                                 <div id="instrument">
                                     <strong>Instrument:</strong> {{ run.instrument.name }}
                                 </div>
+
                                 <div id="rb_number">
-                                    <strong>RB Number:</strong> <a
-                                        href="{% url 'experiment_summary' reference_number=run.experiment.reference_number %}">{{ run.experiment.reference_number }}</a>
+                                    <strong>RB Number:</strong>
+                                        <a href="{% url 'experiment_summary' reference_number=run.experiment.reference_number %}">{{ run.experiment.reference_number }}</a>
                                 </div>
+
                                 <div id="last_updated">
                                     <strong>Last Updated:</strong> {{ run.last_updated }}
                                 </div>
                             </div>
+
                             <div class="col-md-6">
                                 <div>
                                     <strong>Start:</strong>
@@ -116,6 +122,7 @@
                                         <em>Not yet started</em>
                                     {% endif %}
                                 </div>
+
                                 <div>
                                     <strong>Finish:</strong>
                                     {% if is_skipped %}
@@ -126,6 +133,7 @@
                                         <em>Not yet finished</em>
                                     {% endif %}
                                 </div>
+
                                 <div>
                                     <strong>Duration:</strong>
                                     {% if run.started and run.finished %}
@@ -136,14 +144,14 @@
                                         <em>Not yet finished</em>
                                     {% endif %}
                                 </div>
+
                                 <div>
                                     <strong>Retrying:</strong>
                                     {% if run.finished %}
                                         {% if run.retry_when %}
                                             {{ run.retry_when|naturaltime }}
                                             {% if run.retry_run %}
-                                                <a href="{% url 'runs:summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}">
-                                                    ({{ run.retry_run.status.value_verbose }})</a>
+                                                <a href="{% url 'runs:summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}">({{ run.retry_run.status.value_verbose }})</a>
                                             {% endif %}
                                         {% else %}
                                             Never
@@ -152,6 +160,7 @@
                                         <em>Not yet finished</em>
                                     {% endif %}
                                 </div>
+
                                 <div>
                                     <strong>Software used:</strong>
                                     {% if run.software is not null %}
@@ -162,6 +171,7 @@
                                 </div>
                             </div>
                         </div>
+
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="file-path">
@@ -180,7 +190,9 @@
                                 <div class="file-path">
                                     <strong>Reduced:</strong>
                                     {% if reduction_location %}
-                                        <a href="{{ data_analysis_link_url }}" target="_blank">{{ reduction_location }}<i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
+                                        <a href="{{ data_analysis_link_url }}" target="_blank">{{ reduction_location }}
+                                            <i class="fa fa-external-link" aria-hidden="true"></i>
+                                        </a><br/>
                                     {% elif run.reduction_location.all %}
                                         {% for location in run.reduction_location.all %}
                                             {{ location.file_path }}<br/>
@@ -201,39 +213,33 @@
                 </div>
             </div>
         </div>
-        {% if not is_skipped %}
-            <div id="re-run_and_graphs">
-                {% if run.graph %}
-                    <div class="panel panel-default" id="re-run_job">
-                        <div class="panel-heading">
-                            <div class="panel-title"><a data-toggle="collapse" href="#collapseGraphs"
-                                                        data-target="#graphs"><i
-                                    class="fa fa-chevron-down"></i> Images</a></div>
-                        </div>
-                        <div class="panel-body collapse in" id="graphs">
-                            {% for graph in run.graph %}
-                                <div class="text-center"><a href="{{ graph }}" target="_blank"
-                                                            rel="noopener noreferrer"><img src="{{ graph }}"/></a>
-                                </div>
-                            {% endfor %}
+
+        <div id="re-run_and_graphs">
+            {% if run.graph %}
+                <div class="panel panel-default" id="re-run_job">
+                    <div class="panel-heading">
+                        <div class="panel-title">
+                            <a data-toggle="collapse" href="#collapseGraphs" data-target="#graphs">
+                                <i class="fa fa-chevron-down"></i> Images
+                            </a>
                         </div>
                     </div>
-            {% endif %}
-            {% if has_run_variables and has_reduce_vars  %}
-                {% autoescape on %}
-                    {% view "instrument.views.variables.render_run_variables" instrument run_number run_version %}
-                {% endautoescape %}
-            {% elif not has_run_variables %}
-                <div>
-                    <p class="text-center" id="warning_message">No variables found for this run.</p>
-                </div>
-            {% elif not has_reduce_vars %}
-                <div>
-                    <p class="text-center" id="warning_message">The reduce_vars.py script is missing for this instrument. Please create it before being able to submit re-runs.</p>
+
+                    <div class="panel-body collapse in" id="graphs">
+                        {% for graph in run.graph %}
+                            <div class="text-center">
+                                <a href="{{ graph }}" target="_blank" rel="noopener noreferrer"><img src="{{ graph }}"/></a>
+                            </div>
+                        {% endfor %}
+                    </div>
                 </div>
             {% endif %}
+
+            {% autoescape on %}
+                {% view "instrument.views.variables.render_run_variables" instrument run_number run_version %}
+            {% endautoescape %}
         </div>
-        {% endif %}
+
         <div class="row col-md-12 my-2">
             <div class="text-center">
                 {% if newest_run != run.run_number %}
@@ -248,12 +254,15 @@
                 {% endif %}
             </div>
         </div>
+
         <div class="run-history modal fade" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span
-                                class="sr-only">Close</span></button>
+                        <button type="button" class="close" data-dismiss="modal">
+                            <span aria-hidden="true">&times;</span>
+                            <span class="sr-only">Close</span>
+                        </button>
                         <h3 class="modal-title">Job History</h3>
                     </div>
                     <div class="modal-body">
@@ -277,7 +286,8 @@
                                             {% endif %}
                                         </td>
                                         <td class="text-{% colour_table_row job.status.value_verbose %}">
-                                            <strong>{{ job.status.value_verbose }}</strong></td>
+                                                <strong>{{ job.status.value_verbose }}</strong>
+                                        </td>
                                         <td title="{{ job.last_updated|date:'SHORT_DATETIME_FORMAT' }}">{{ job.last_updated|naturaltime }}</td>
                                         <td>
                                             {% if started_by %}
@@ -299,8 +309,10 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span
-                                class="sr-only">Close</span></button>
+                        <button type="button" class="close" data-dismiss="modal">
+                            <span aria-hidden="true">&times;</span>
+                            <span class="sr-only">Close</span>
+                        </button>
                         <h4 class="modal-title">Reduction logs</h4>
                     </div>
                     <div class="modal-body">
@@ -312,18 +324,16 @@
     {% endif %}
 {% endblock %}
 
-
-
 {% block stylesheets %}
     <link rel="stylesheet" href="{% static 'css/vendor/prettify.css' %}">
     <link rel="stylesheet" href="{% static 'css/vendor/bootstrap-tour.min.css' %}">
 {% endblock %}
+
 {% block scripts %}
     <script src="{% static 'javascript/run_summary.js' %}"></script>
     <script src="{% static 'javascript/vendor/prettify.js' %}"></script>
     <script src="{% static 'javascript/run_variables.js' %}"></script>
     <script src="{% static 'javascript/vendor/bootstrap-tour.min.js' %}"></script>
-
     <script src="{% static 'javascript/tours/run_summary_tour.js' %}"></script>
     <script src="{% static 'javascript/tours/navbar_tour.js' %}"></script>
     <script src="{% static 'javascript/create_tour.js' %}"></script>

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -233,21 +233,21 @@
                 </div>
             {% endif %}
         </div>
-            <div class="row col-md-12 my-2">
-                <div class="text-center">
-                    {% if newest_run != run.run_number %}
-                        {% if newest_run != next_run %}
-                            <a href="{% url 'runs:summary' instrument_name=instrument run_number=newest_run run_version=run.run_version %}?{% get_run_navigation_queries newest_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="newest">&#60&#60 {{ newest_run }}</a>
-                        {% endif %}
-                        <a href="{% url 'runs:summary' instrument_name=instrument run_number=next_run run_version=run.run_version %}?{% get_run_navigation_queries next_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="next">&#60 {{ next_run }}</a>
-                    {% endif %}
-                    <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&pagination={{ items_per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
-                    {% if oldest_run != run.run_number %}
-                        <a href="{% url 'runs:summary' instrument_name=instrument run_number=previous_run run_version=run.run_version %}?{% get_run_navigation_queries previous_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="previous">{{ previous_run }} &#62</a>
-                    {% endif %}
-                </div>
-            </div>
         {% endif %}
+        <div class="row col-md-12 my-2">
+            <div class="text-center">
+                {% if newest_run != run.run_number %}
+                    {% if newest_run != next_run %}
+                        <a href="{% url 'runs:summary' instrument_name=instrument run_number=newest_run run_version=run.run_version %}?{% get_run_navigation_queries newest_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="newest">&#60&#60 {{ newest_run }}</a>
+                    {% endif %}
+                    <a href="{% url 'runs:summary' instrument_name=instrument run_number=next_run run_version=run.run_version %}?{% get_run_navigation_queries next_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="next">&#60 {{ next_run }}</a>
+                {% endif %}
+                <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&pagination={{ items_per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
+                {% if oldest_run != run.run_number %}
+                    <a href="{% url 'runs:summary' instrument_name=instrument run_number=previous_run run_version=run.run_version %}?{% get_run_navigation_queries previous_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="previous">{{ previous_run }} &#62</a>
+                {% endif %}
+            </div>
+        </div>
         <div class="run-history modal fade" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/autoreduce_frontend/templates/snippets/run_variables.html
+++ b/autoreduce_frontend/templates/snippets/run_variables.html
@@ -51,7 +51,19 @@
             </div>
             <div class="form-group variables-buttons">
                 <div class="col-md-9 text-right">
-                    <input type="submit" value="Re-run with new variables" class="btn btn-success" id="variableSubmit" />
+                    {% if not has_reduce_vars %}
+                    <div class="alert alert-warning">
+                        <p class="text-center " id="warning_message">
+                            <i class="fa fa-exclamation-triangle"></i>
+                                &nbsp;&nbsp;The reduce_vars.py script is missing for this instrument. Please create it before being able to submit re-runs.
+                        </p>
+                    </div>
+                    {% endif %}
+                    <input type="submit" value="Re-run with new variables" class="btn btn-success" id="variableSubmit"
+                        {% if not has_reduce_vars %}
+                            disabled
+                        {% endif %}
+                    />
                 </div>
             </div>
         </form>


### PR DESCRIPTION
### Summary of work
Display re-run and back buttons for runs that don't have reduce_vars.py or run variables.

### How to test your work
Navigate to an instrument's run summary that didn't previously have the re-run or back buttons displayed. Click on the buttons to see if they function as intended.

Fixes AR-1395