### PR TITLE
Display greyed out run summary navigation buttons

### DIFF
--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -102,7 +102,7 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
 
     def plotly_plots(self) -> List[WebElement]:
         """Return all plotly plot elements."""
-        return self.driver.find_elements_by_tag_name("img")
+        return self.driver.find_elements_by_class_name("js-plotly-plot")
 
     def _do_cancel_btn(self, url):
         def run_button_clicked_successfully(button, url, driver):

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -123,3 +123,7 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         """Click the button with the given id."""
         btn = self.driver.find_element_by_id(btn_id)
         btn.click()
+
+    def is_disabled(self, element_id):
+        """Return true if the element with the given id is disabled."""
+        return self.driver.find_element_by_id(element_id).get_attribute("disabled") == "true"

--- a/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/run_summary_page.py
@@ -20,9 +20,7 @@ from autoreduce_frontend.selenium_tests.pages.page import Page
 
 
 class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
-    """
-    Page model class for run summary page
-    """
+    """Page model class for run summary page."""
     def __init__(self, driver, instrument, run_number, version):
         super().__init__(driver)
         self.instrument = instrument
@@ -30,10 +28,7 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         self.version = version
 
     def url_path(self) -> str:
-        """
-        Return the current URL of the page.
-        :return: (str) the url path
-        """
+        """Return the current URL of the page."""
         return reverse("runs:summary",
                        kwargs={
                            "instrument_name": self.instrument,
@@ -43,94 +38,70 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
 
     @property
     def reduction_job_panel(self) -> WebElement:
-        """Finds the run summary panel on the page."""
+        """Return the run summary panel on the page."""
         return self.driver.find_element_by_id("reduction_job_panel")
 
     @property
     def rerun_form(self) -> WebElement:
-        """Finds and returns the rerun form on the page"""
+        """Return the rerun form."""
         return self.driver.find_element_by_id("rerun_form")
 
     @property
     def toggle_button(self) -> WebElement:
-        """
-        Finds and returns the toggle button for toggling the form on the page.
-        """
+        """Return the toggle button."""
         return self.driver.find_element_by_id("toggle_form")
 
     @property
     def reset_to_initial_values(self) -> WebElement:
-        """
-        Finds and returns the "Reset to original script and values" button
-        """
+        """Return the `Reset to original script and values` button."""
         return self.driver.find_element_by_id("resetValues")
 
     @property
     def reset_to_current_values(self) -> WebElement:
         """
-        Finds and returns the "Reset to values in the current reduce_vars script" button
+        Return the `Reset to values in the current reduce_vars script` button.
         """
         return self.driver.find_element_by_id("currentScript")
 
     @property
     def warning_message(self) -> WebElement:
-        """
-        Finds and returns the "warning_message" box
-        """
+        """Return the 'warning_message' box."""
         return self.driver.find_element_by_id("warning_message")
 
     def run_description_text(self) -> str:
-        """
-        Finds and returns the text of the run_description field
-        """
+        """Return the text of the run_description field."""
         return self.driver.find_element_by_id("run_description").text
 
     def started_by_text(self) -> str:
-        """
-        Finds and returns the text of the started_by field
-        """
+        """Return the text of the started_by field."""
         return self.driver.find_element_by_id("started_by").text
 
     def status_text(self) -> str:
-        """
-        Finds and returns the text of the status field
-        """
+        """Return the text of the status field."""
         return self.driver.find_element_by_id("status").text
 
     def instrument_text(self) -> str:
-        """
-        Finds and returns the text of the instrument field
-        """
+        """Return the text of the instrument field."""
         return self.driver.find_element_by_id("instrument").text
 
     def rb_number_text(self) -> str:
-        """
-        Finds and returns the text of the rb_number field
-        """
+        """Return the text of the rb_number field."""
         return self.driver.find_element_by_id("rb_number").text
 
     def last_updated_text(self) -> str:
-        """
-        Finds and returns the text of the last_updated field
-        """
+        """Return the text of the last_updated field."""
         return self.driver.find_element_by_id("last_updated").text
 
     def reduction_host_text(self) -> WebElement:
-        """
-        Returns the reduction host text
-        """
+        """Return the reduction host text."""
         return self.driver.find_element_by_id("reduction_host").text
 
     def images(self) -> List[WebElement]:
-        """
-        Returns all image elements on the page.
-        """
+        """Returns all image elements on the page."""
         return self.driver.find_elements_by_tag_name("img")
 
     def plotly_plots(self) -> List[WebElement]:
-        """
-        Returns all image elements on the page.
-        """
+        """Return all plotly elements on the page."""
         return self.driver.find_elements_by_class_name("js-plotly-plot")
 
     def _do_cancel_btn(self, url):
@@ -149,6 +120,6 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         return RunsListPage(self.driver, self.instrument)
 
     def click_btn_by_id(self, btn_id: str) -> None:
-        """Click the button with the specified ID."""
+        """Click the button with the given id."""
         btn = self.driver.find_element_by_id(btn_id)
         btn.click()

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -72,9 +72,9 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         Click the button matching the given title.
 
         Note:
-            This method is being used to navgiate between instrument summary
-            pages as there is no `find_element_by_title` method and the
-            instrument summary navigation buttons have no id attributes.
+            This method is being used to navigate instrument summary pages as
+            there is no `find_element_by_title` method and the instrument
+            summary navigation buttons have no id attributes.
         """
         btns = self.driver.find_elements_by_tag_name("button")
 
@@ -85,7 +85,7 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         else:
             raise NoSuchElementException
 
-    def update_filter(self, filter_name, value):  #items_per_page_option(self, pagination: int) -> None:
+    def update_filter(self, filter_name, value):
         """
         Select a valid filter option.
 

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -4,14 +4,13 @@
 # Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
-"""
-Module for the instrument summary page model
-"""
+"""Module for the instrument summary page model."""
 from typing import List
 
 from django.urls import reverse
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import Select
+
 from autoreduce_frontend.selenium_tests.pages.component_mixins.footer_mixin import FooterMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.navbar_mixin import NavbarMixin
 from autoreduce_frontend.selenium_tests.pages.component_mixins.tour_mixin import TourMixin
@@ -20,34 +19,33 @@ from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummary
 
 
 class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
-    """
-    Page model class for instrument summary page
-    """
+    """Page model class for instrument summary page."""
     def __init__(self, driver, instrument):
         super().__init__(driver)
         self.instrument = instrument
 
     def url_path(self):
-        """
-        Return the path section of the instrument url
-        :return: (str) Path section of the page url
-        """
+        """Return the path section of the instrument url."""
         return reverse("runs:list", kwargs={"instrument": self.instrument})
 
     def get_run_numbers_from_table(self) -> List[str]:
         """
-        Get the list of run numbers visible on the current table of the instrument summary page
-        :return: (List) List of strings of the run numbers of the current instrument summary page
+        Return the list of run numbers visible on the current table of the
+        instrument summary page.
         """
         return [run.text.split(" - ")[0] for run in self.driver.find_elements_by_class_name("run-num-links")]
 
     def click_run(self, run_number: int, version: int = 0) -> RunSummaryPage:
         """
-        Click the run number link on the instrument summary table matching the given run number and
-        version
-        :param run_number: (int) the run number of the link to click
-        :param version: (int) the version of the run to click
-        :return: (RunSummaryPage) The page object of the opened run summary page.
+        Click a run and return the page object of its run summary.
+
+        Args:
+            run_number: Run number of the link to click.
+
+            version: Version of the run to click.
+
+        Returns:
+            The page object of the opened run summary.
         """
         runs = self.driver.find_elements_by_class_name("run-num-links")
         run_string = f"{run_number} - {version}" if version else f"{run_number}"
@@ -55,18 +53,29 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
             if run.text == run_string:
                 run.click()
                 return RunSummaryPage(self.driver, self.instrument, run_number, version)
+
         raise NoSuchElementException
 
     def alert_message_text(self) -> str:
-        """Get the the from the alert message"""
+        """
+        Return the text of the alert message element with the id
+        'alert_message'.
+        """
         return self.driver.find_element_by_id("alert_message").text.strip()
 
     def get_top_run(self) -> None:
-        """Get the top run using the element's id."""
+        """Return the element with the id 'top-run-number'."""
         return self.driver.find_element_by_id("top-run-number")
 
-    def click_page_by_title(self, title: str) -> None:
-        """Click the page navigation button matching the given title."""
+    def click_btn_by_title(self, title: str) -> None:
+        """
+        Click the button matching the given title.
+
+        Note:
+            This method is being used to navgiate between instrument summary
+            pages as there is no `find_element_by_title` method and the
+            instrument summary navigation buttons have no id attributes.
+        """
         btns = self.driver.find_elements_by_tag_name("button")
 
         for btn in btns:
@@ -76,24 +85,18 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         else:
             raise NoSuchElementException
 
-    def update_items_per_page_option(self, pagination: int) -> None:
+    def update_filter(self, filter_name, value):  #items_per_page_option(self, pagination: int) -> None:
         """
-        Select the supplied pagination option from the 'Items per page' combo
-        box.
-        """
-        pagination_select = Select(self.driver.find_element_by_id("pagination_select"))
-        pagination_select.select_by_visible_text(str(pagination))
+        Select a valid filter option.
 
-    def update_sort_by_option(self, sort_by: str) -> None:
-        """Select the supplied sort by option from the 'Sort by' combo box."""
-        pagination_select = Select(self.driver.find_element_by_id("sort_select"))
-        pagination_select.select_by_visible_text(sort_by)
+        Args:
+            filter_name: The name of the filter type being updated.
+
+            value: The new value of the given filter.
+        """
+        Select(self.driver.find_element_by_id(filter_name)).select_by_visible_text(value)
 
     def click_apply_filters(self) -> None:
-        "Click the 'Apply filters' button."
+        """Click the `Apply filters` button."""
         btn = self.driver.find_element_by_id("apply_filters")
         btn.click()
-
-    def get_run_btns_by_cls_name(self, cls_name: str) -> None:
-        """Return all elements containing the specified class name."""
-        return self.driver.find_elements_by_class_name(cls_name)

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
@@ -130,8 +130,8 @@ class TestRunsListQueries(BaseTestCase, AccessibilityTestMixin, FooterTestMixin,
 
     def test_disabled_btns(self):
         """
-        Test that run navigation buttons are disabled for certain runs depending
-        on their recency.
+        Test that the run summary navigation buttons are disabled depending on a
+        runs' recency.
 
         The latest run should have the `Newest` and `Next` buttons disabled.
 

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list_page.py
@@ -47,7 +47,7 @@ class TestRunsListPage(BaseTestCase, AccessibilityTestMixin, FooterTestMixin, Na
         data_archive = DataArchive([self.instrument_name], 21, 21)
         data_archive.create()
 
-        # add a reduce_vars script with a syntax error -> a missing " after value1
+        # Add a reduce_vars script with a syntax error -> missing " after value1
         data_archive.add_reduce_vars_script(self.instrument_name, """standard_vars={"variable1":"value1}""")
 
         self.page.launch()
@@ -71,17 +71,17 @@ class TestRunsListQueries(BaseTestCase, AccessibilityTestMixin, FooterTestMixin,
     def _test_page_query(self, query):
         """
         Test that the given query is in a run's URL after clicking a run and
-        then clicking the 'Back to <InstrumentName> runs' button.
+        then clicking the `Back to <InstrumentName> runs` button.
         """
         assert query in self.page.get_top_run().get_attribute('href')
 
-        # Check queries runs after clicking the top run
+        # Check query after clicking the top run
         top_run_num = int(self.page.get_top_run().text)
         run_summary_page = self.page.click_run(top_run_num)
         assert query in run_summary_page.driver.current_url
         assert query in run_summary_page.cancel_button.get_attribute('href')
 
-        # Check queries after returning to runs list
+        # Check query after returning to runs list
         runs_list_page = run_summary_page.click_cancel_btn()
         assert query in runs_list_page.get_top_run().get_attribute('href')
         assert query in runs_list_page.driver.current_url
@@ -92,14 +92,14 @@ class TestRunsListQueries(BaseTestCase, AccessibilityTestMixin, FooterTestMixin,
             self.page.launch()
             self._test_page_query(query + ("1" if query == "page=" else ""))
 
-            self.page.click_page_by_title("Next Page")
+            self.page.click_btn_by_title("Next Page")
             self._test_page_query(query + ("2" if query == "page=" else ""))
 
     def test_pagination_filter(self):
         """Test that changing the pagination filter also updates the URL query."""
         for pagination in (10, 25, 50, 100, 250, 500):
             self.page.launch()
-            self.page.update_items_per_page_option(pagination)
+            self.page.update_filter("pagination_select", str(pagination))
             self.page.click_apply_filters()
             self._test_page_query(f"pagination={pagination}")
 
@@ -107,19 +107,45 @@ class TestRunsListQueries(BaseTestCase, AccessibilityTestMixin, FooterTestMixin,
         """Test that changing the sort by filter also updates the URL query."""
         for sort in ("number", "date"):
             self.page.launch()
-            self.page.update_sort_by_option(sort.title())
+            self.page.update_filter("sort_select", sort.title())
             self.page.click_apply_filters()
 
+            # Sorting by number is referred to as 'run' for the URL query
             if sort == "number":
                 sort = "run"
 
             self._test_page_query(f"sort={sort}")
 
     def test_run_navigation_btns(self):
-        """Test that the run navigation buttons work."""
+        """
+        Test that the run navigation buttons work. Begin from the fifth run in
+        the fixture.
+        """
         for nav in ("newest", "next", "previous"):
             self.page.launch()
-            runs = self.page.get_run_btns_by_cls_name("run-num-links")
-            fifth_displayed_run = runs[4]
-            run_summary_page = self.page.click_run(int(fifth_displayed_run.text))
+            runs = self.page.get_run_numbers_from_table()
+            fifth_run = runs[4]
+            run_summary_page = self.page.click_run(fifth_run)
             run_summary_page.click_btn_by_id(nav)
+
+    def test_disabled_btns(self):
+        """
+        Test that run navigation buttons are disabled for certain runs depending
+        on their recency.
+
+        The latest run should have the `Newest` and `Next` buttons disabled.
+
+        The oldest run should have the `Previous` button disabled.
+
+        Note:
+            This test assumes that the runs are being sorted by number.
+        """
+        for btn_id, run_number in (("newest", 100009), ("next", 100009), ("previous", 99999)):
+            self.page.launch()
+
+            # The first run is on the second page so need to navigate to it
+            if run_number == 99999:
+                self.page.click_btn_by_title("Next Page")
+
+            run_summary_page = self.page.click_run(run_number)
+            assert run_summary_page.is_disabled(btn_id)

--- a/autoreduce_frontend/templates/filtered_by_reference.html
+++ b/autoreduce_frontend/templates/filtered_by_reference.html
@@ -15,7 +15,7 @@
             {% for run in associated_runs %}
                 <div class="row run-row-internal">
                     <div class="col-md-5 col-sm-5 col-md-offset-1 col-xs-4">
-                        <a href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}?filter={{ filtering }}">{{ run.title }}</a>
+                        <a href="{% url 'runs:summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}?sort={{ sort }}&filter={{ filtering }}">{{ run.title }}</a>
                     </div>
                     <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}">
                         <strong>{{ run.status.value_verbose }}</strong>

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -235,16 +235,24 @@
         </div>
             <div class="row col-md-12 my-2">
                 <div class="text-center">
-                    {% if newest_run != run.run_number %}
-                        {% if newest_run != next_run %}
-                            <a href="{% url 'runs:summary' instrument_name=instrument run_number=newest_run run_version=run.run_version %}?{% get_run_navigation_queries newest_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="newest">&#60&#60 {{ newest_run }}</a>
-                        {% endif %}
-                        <a href="{% url 'runs:summary' instrument_name=instrument run_number=next_run run_version=run.run_version %}?{% get_run_navigation_queries next_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="next">&#60 {{ next_run }}</a>
-                    {% endif %}
-                    <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&pagination={{ items_per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
-                    {% if oldest_run != run.run_number %}
-                        <a href="{% url 'runs:summary' instrument_name=instrument run_number=previous_run run_version=run.run_version %}?{% get_run_navigation_queries previous_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="previous">{{ previous_run }} &#62</a>
-                    {% endif %}
+                    <a href="{% url 'runs:summary' instrument_name=instrument run_number=newest_run run_version=run.run_version %}?{% get_run_navigation_queries newest_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="newest"
+                        {% if newest_run == run.run_number %}
+                            disabled
+                        {% endif%}>&#124;&#60; Newest
+                    </a>
+                    <a href="{% url 'runs:summary' instrument_name=instrument run_number=next_run run_version=run.run_version %}?{% get_run_navigation_queries next_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="next"
+                        {% if newest_run == run.run_number %}
+                            disabled
+                        {% endif%}>&#60;&#60; Next
+                    </a>
+                    <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&pagination={{ items_per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel"
+                        >Back to {{ run.instrument.name }} runs
+                    </a>
+                    <a href="{% url 'runs:summary' instrument_name=instrument run_number=previous_run run_version=run.run_version %}?{% get_run_navigation_queries previous_run current_page newest_run oldest_run %}&pagination={{ items_per_page }}&sort={{ page_type }}" class="btn btn-primary back" id="previous"
+                        {% if oldest_run == run.run_number %}
+                            disabled
+                        {% endif%}>Previous &#62;&#62;
+                    </a>
                 </div>
             </div>
         {% endif %}

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -331,7 +331,6 @@
     <script src="{% static 'javascript/vendor/prettify.js' %}"></script>
     <script src="{% static 'javascript/run_variables.js' %}"></script>
     <script src="{% static 'javascript/vendor/bootstrap-tour.min.js' %}"></script>
-
     <script src="{% static 'javascript/tours/run_summary_tour.js' %}"></script>
     <script src="{% static 'javascript/tours/navbar_tour.js' %}"></script>
     <script src="{% static 'javascript/create_tour.js' %}"></script>


### PR DESCRIPTION
### Summary of work
When run summary navigation buttons aren't required, display greyed out buttons instead of not displaying them at all  -- stops the buttons from moving horizontally when navigating between run summaries. 

Also, replace the run numbers within the navigation buttons with their recency instead, e.g:

Before:
`<< 611201` `< 611997` `Back to runs` `611995 >`

After:
`|< Newest` `<< Next` `Back to runs` `Previous >>`

### How to test your work
Navigate to any run summary and navigate between runs using the navigation buttons. When you reach the latest run, the "Newest" and "Next" buttons should be greyed out. Likewise, when you navigate to the first run, the "Previous" button should be greyed out.