### PR TITLE
Return '0 seconds' when all time values are 0

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/templatetags/natural_time_difference.py
+++ b/autoreduce_frontend/autoreduce_webapp/templatetags/natural_time_difference.py
@@ -29,6 +29,9 @@ class NaturalTimeDifferenceNode(Node):
         minutes = delta.seconds // 60 % 60
         seconds = delta.seconds % 60
 
+        if not any((days, hours, minutes, seconds)):
+            return "0 seconds"
+
         duration = ''
         for time, unit in ((days, "day"), (hours, "hour"), (minutes, "minute"), (seconds, "second")):
             if time > 0:

--- a/autoreduce_frontend/autoreduce_webapp/templatetags/test/test_natural_time_difference.py
+++ b/autoreduce_frontend/autoreduce_webapp/templatetags/test/test_natural_time_difference.py
@@ -8,7 +8,6 @@
 Unit tests for the script which determines the natural time difference between
 the start and end of a run.
 """
-
 import datetime
 import unittest
 
@@ -28,7 +27,7 @@ class TestNaturalTimeDifference(unittest.TestCase):
 
     def test_difference_none(self):
         """Test that no time difference returns an empty string."""
-        self._test_time_difference(TestNaturalTimeDifference.START_DATETIME, "")
+        self._test_time_difference(TestNaturalTimeDifference.START_DATETIME, "0 seconds")
 
     @parameterized.expand([
         [START_DATETIME + datetime.timedelta(seconds=1), "1 second"],


### PR DESCRIPTION
### Summary of work
`NaturalTimeDifferenceNode.get_duration()` returns '0 seconds' if all time values equal 0.