### PR TITLE
Adds debug_toolbar back when running in DEBUG mode AR-1533

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -34,7 +34,15 @@ SECRET_KEY = get_str("WEBAPP", "secret_key")
 # having to run `manage.py collectstatic` each time. On production
 # we use Apache to serve static content instead.
 DEBUG = not "AUTOREDUCTION_PRODUCTION" in os.environ
+
 DEBUG_PROPAGATE_EXCEPTIONS = True
+DEBUG_TOOLBAR_AVAILABLE = False
+if DEBUG:
+    try:
+        import debug_toolbar
+        DEBUG_TOOLBAR_AVAILABLE = True
+    except ImportError:
+        pass
 
 if DEBUG:
     ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'reducedev2.isis.cclrc.ac.uk']
@@ -51,6 +59,9 @@ INSTALLED_APPS = [
     'autoreduce_db.instrument', 'rest_framework.authtoken'
 ]
 
+if DEBUG and DEBUG_TOOLBAR_AVAILABLE:
+    INSTALLED_APPS.append('debug_toolbar')
+
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -60,6 +71,9 @@ MIDDLEWARE = [
     'django_user_agents.middleware.UserAgentMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+if DEBUG and DEBUG_TOOLBAR_AVAILABLE:
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
 AUTHENTICATION_BACKENDS = [
     'autoreduce_frontend.autoreduce_webapp.backends.UOWSAuthenticationBackend',


### PR DESCRIPTION
### Summary of work
Adds debug_toolbar back when running in DEBUG mode. At some point I've accidentally removed adding that in!

### How to test your work
1. Checkout this branch & `pip install django-debug-toolbar`
2. Run/restart the webapp, open a page and this should now be visible in the top right corner:
![image](https://user-images.githubusercontent.com/9135965/135872260-a99f8dfb-1905-4161-9154-04c43eba3f4a.png)
3. Click it for some statistics:
![image](https://user-images.githubusercontent.com/9135965/135872337-85b0cfa7-b2a2-43f4-b6d9-f6ac1e55e7fa.png)