### PR TITLE
Going to non-existent run number or version no longer shows an error AR-1574

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/fixtures/batch_run_with_one_variable.json
+++ b/autoreduce_frontend/autoreduce_webapp/fixtures/batch_run_with_one_variable.json
@@ -1,0 +1,47 @@
+[
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 2,
+        "fields": {
+            "status_id": 5,
+            "run_version": 0,
+            "run_description": "This is the test run_description",
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1,
+            "started_by": -1,
+            "reduction_host": "test-host-123",
+            "script_id": 1,
+            "arguments_id": 1,
+            "batch_run": true
+        }
+    },
+    {
+        "model": "reduction_viewer.runnumber",
+        "pk": 2,
+        "fields": {
+            "run_number": 99999,
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "reduction_viewer.runnumber",
+        "pk": 3,
+        "fields": {
+            "run_number": 100000,
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "pk": 1,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 2
+        }
+    }
+]

--- a/autoreduce_frontend/reduction_viewer/views/run_summary.py
+++ b/autoreduce_frontend/reduction_viewer/views/run_summary.py
@@ -24,7 +24,8 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
                                           run_numbers__run_number=run_number).order_by('-run_version').select_related(
                                               'status').select_related('experiment').select_related('instrument')
     if len(history) == 0:
-        raise ValueError(f"Could not find any matching runs for instrument {instrument_name} run {run_number}")
+        return redirect("{}?message=Run {}-{} does not exist. Redirected to the instrument page.".format(
+            reverse("runs:list", kwargs={'instrument': instrument_name}), run_number, run_version))
 
     return run_summary_run(request, history, instrument_name, run_version, run_number)
 

--- a/autoreduce_frontend/reduction_viewer/views/run_summary.py
+++ b/autoreduce_frontend/reduction_viewer/views/run_summary.py
@@ -14,14 +14,22 @@ LOGGER = logging.getLogger(__package__)
 
 
 def redirect_run_does_not_exist(instrument_name, run_number, run_version):
+    """
+    Redirects to the runs:list page if the run does not exist, and shows which run was not found.
+
+    Args:
+        instrument_name: The instrument name of the run.
+        run_number: The run number of the run.
+        run_version: The run version of the run.
+    """
     return redirect("{}?message=Run {}-{} does not exist. Redirected to the instrument page.".format(
         reverse("runs:list", kwargs={'instrument': instrument_name}), run_number, run_version))
 
 
+# pylint:disable=no-member,too-many-locals,broad-except
 @login_and_uows_valid
 @check_permissions
 @render_with('run_summary.html')
-# pylint:disable=no-member,too-many-locals,broad-except
 def run_summary(request, instrument_name=None, run_number=None, run_version=0):
     """Render run summary."""
     history = ReductionRun.objects.filter(instrument__name=instrument_name,

--- a/autoreduce_frontend/reduction_viewer/views/runs_list.py
+++ b/autoreduce_frontend/reduction_viewer/views/runs_list.py
@@ -72,7 +72,8 @@ def runs_list(request, instrument=None):
             'run_table': run_table,
             'per_page': request.GET.get('per_page', 10),
             'current_page': request.GET.get('page', 1),
-            'options_form': options_form
+            'options_form': options_form,
+            'info_message': request.GET.get('message', ''),
         }
 
         if filter_by == 'experiment':

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -78,12 +78,12 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
 
         raise NoSuchElementException
 
-    def alert_message_text(self) -> str:
+    def variables_alert_message_text(self) -> str:
         """
         Return the text of the alert message element with the id
         'alert_message'.
         """
-        return self.driver.find_element_by_id("alert_message").text.strip()
+        return self.driver.find_element_by_id("variables_alert_message").text.strip()
 
     def get_top_run(self) -> WebElement:
         """Return the element with the id 'top-run-number'."""
@@ -136,3 +136,7 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
         """Click the `Apply filters` button."""
         btn = self.driver.find_element_by_id("apply_filters")
         btn.click()
+
+    @property
+    def top_alert_message_text(self):
+        return self.driver.find_element_by_id("top-alert-message").text

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -139,4 +139,5 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
 
     @property
     def top_alert_message_text(self):
+        """Finds and returns the alert message shown at the top of the runs list page"""
         return self.driver.find_element_by_id("top-alert-message").text

--- a/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
+++ b/autoreduce_frontend/selenium_tests/pages/runs_list_page.py
@@ -81,7 +81,7 @@ class RunsListPage(Page, NavbarMixin, FooterMixin, TourMixin):
     def variables_alert_message_text(self) -> str:
         """
         Return the text of the alert message element with the id
-        'alert_message'.
+        'variable_alert_message'.
         """
         return self.driver.find_element_by_id("variables_alert_message").text.strip()
 

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary.py
@@ -13,7 +13,8 @@ from autoreduce_db.reduction_viewer.models import ReductionRun
 from autoreduce_frontend.autoreduce_webapp.templatetags.encode_b64 import encode_b64
 from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
 from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
-from autoreduce_frontend.selenium_tests.tests.base_tests import ConfigureNewJobsBaseTestCase, FooterTestMixin, NavbarTestMixin
+from autoreduce_frontend.selenium_tests.tests.base_tests import (ConfigureNewJobsBaseTestCase, FooterTestMixin,
+                                                                 NavbarTestMixin)
 
 
 # pylint:disable=no-member

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
@@ -6,25 +6,42 @@
 # ############################################################################### #
 """Selenium tests for the runs summary page."""
 
+from autoreduce_db.reduction_viewer.models import ReductionRun
 from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
 from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
-from autoreduce_frontend.selenium_tests.tests.pages.test_run_summary import TestRunSummaryPage
+
+from autoreduce_frontend.selenium_tests.tests.base_tests import ConfigureNewJobsBaseTestCase
 
 
 # pylint:disable=no-member
-class TestBatchRunSummaryPage(TestRunSummaryPage):
+class TestBatchRunSummaryPage(ConfigureNewJobsBaseTestCase):
     """
     Test cases for the InstrumentSummary page when the Rerun form is NOT
     visible.
     """
 
-    fixtures = TestRunSummaryPage.fixtures + ["batch_run_with_one_variable"]
+    fixtures = ConfigureNewJobsBaseTestCase.fixtures + ["run_with_one_variable", "batch_run_with_one_variable"]
 
     def setUp(self) -> None:
         """Set up RunSummaryPage before each test case."""
         super().setUp()
         self.page = RunSummaryPage(self.driver, self.instrument_name, 2, 0, batch_run=True)
         self.page.launch()
+
+    def test_reduction_job_panel_displayed(self):
+        """Test that the reduction job panel is showing the right things."""
+        # only one run in the fixture, get it for assertions
+        run = ReductionRun.objects.last()
+        assert self.page.reduction_job_panel.is_displayed()
+        assert self.page.run_description_text() == f"Run description: {run.run_description}"
+        # because it's started_by: -1, determined in `started_by_id_to_name`
+        assert self.page.started_by_text() == "Started by: Development team"
+        assert self.page.status_text() == "Status: Completed"
+        assert self.page.instrument_text() == f"Instrument: {run.instrument.name}"
+        assert self.page.rb_number_text() == f"RB Number: {run.experiment.reference_number}"
+        assert self.page.last_updated_text() == "Last Updated: 19 Oct 2020, 6:35 p.m."
+        assert self.page.data_path_text() == "Data: /tmp"
+        assert self.page.reduction_host_text() == "Host: test-host-123"
 
     def test_non_existent_run(self):
         """

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
@@ -1,0 +1,146 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+"""Selenium tests for the runs summary page."""
+
+from django.urls import reverse
+from selenium.webdriver.support.wait import WebDriverWait
+
+from autoreduce_db.reduction_viewer.models import ReductionRun
+from autoreduce_frontend.autoreduce_webapp.templatetags.encode_b64 import encode_b64
+from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
+from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
+from autoreduce_frontend.selenium_tests.tests.base_tests import ConfigureNewJobsBaseTestCase, FooterTestMixin, NavbarTestMixin
+
+
+# pylint:disable=no-member
+class TestRunSummaryPage(ConfigureNewJobsBaseTestCase):
+    """
+    Test cases for the InstrumentSummary page when the Rerun form is NOT
+    visible.
+    """
+
+    fixtures = ConfigureNewJobsBaseTestCase.fixtures + ["run_with_one_variable", "batch_run_with_one_variable"]
+
+    def setUp(self) -> None:
+        """Set up RunSummaryPage before each test case."""
+        super().setUp()
+        self.page = RunSummaryPage(self.driver, self.instrument_name, 2, 0, batch_run=True)
+        self.page.launch()
+
+    def test_reduction_job_panel_displayed(self):
+        """Test that the reduction job panel is showing the right things."""
+        # only one run in the fixture, get it for assertions
+        run = ReductionRun.objects.first()
+        assert self.page.reduction_job_panel.is_displayed()
+        assert self.page.run_description_text() == f"Run description: {run.run_description}"
+        # because it's started_by: -1, determined in `started_by_id_to_name`
+        assert self.page.started_by_text() == "Started by: Development team"
+        assert self.page.status_text() == "Status: Completed"
+        assert self.page.instrument_text() == f"Instrument: {run.instrument.name}"
+        assert self.page.rb_number_text() == f"RB Number: {run.experiment.reference_number}"
+        assert self.page.last_updated_text() == "Last Updated: 19 Oct 2020, 6:35 p.m."
+        assert self.page.data_path_text() == "Data: /tmp"
+        assert self.page.reduction_host_text() == "Host: test-host-123"
+
+    def test_reduction_job_panel_reset_to_values_first_used_for_run(self):
+        """
+        Test that the button to reset the variables to the values first used for
+        the run works.
+        """
+        self.page.toggle_button.click()
+        self.page.variable1_field = "the new value in the field"
+
+        self.page.reset_to_initial_values.click()
+
+        # need to re-query the driver because resetting replaces the elements
+        assert self.page.variable1_field.get_attribute("value") == "value1"
+
+    def test_reduction_job_panel_reset_to_current_reduce_vars(self):
+        """
+        Test that the button to reset the variables to the values from the
+        reduce_vars script works.
+        """
+        self.page.toggle_button.click()
+        self.page.variable1_field = "the new value in the field"
+
+        self.page.reset_to_current_values.click()
+
+        # need to re-query the driver because resetting replaces the elements
+        assert self.page.variable1_field.get_attribute("value") == "test_variable_value_123"
+
+    def test_rerun_form(self):
+        """
+        Test that the rerun form shows contents from Variable in database (from
+        the fixture) and not reduce_vars.py.
+        """
+        rerun_form = self.page.rerun_form
+        assert not rerun_form.is_displayed()
+        self.page.toggle_button.click()
+        assert rerun_form.is_displayed()
+        assert rerun_form.find_element_by_id(f"var-standard-{encode_b64('variable1')}").get_attribute(
+            "value") == "value1"
+        labels = rerun_form.find_elements_by_tag_name("label")
+
+        WebDriverWait(self.driver, 10).until(lambda _: labels[0].text == "Re-run description")
+        WebDriverWait(self.driver, 10).until(lambda _: labels[1].text == "variable1")
+
+    def test_back_to_instruments_goes_back(self):
+        """Test that clicking back goes back to the instrument."""
+        back = self.page.cancel_button
+        assert back.is_displayed()
+        assert back.text == f"Back to {self.instrument_name} runs"
+        back.click()
+        assert reverse("runs:list", kwargs={"instrument": self.instrument_name}) in self.driver.current_url
+
+    def test_reset_single_to_initial(self):
+        """
+        Tests changing the value of a variable field and resetting to the
+        initial value, by using the inline button.
+        """
+        self.page.toggle_button.click()
+        initial_value = self.page.variable1_field_val
+        self.page.variable1_field = "the new value in the field"
+        assert self.page.variable1_field_val != initial_value
+
+        self.page.variable1_field_reset_buttons.to_initial.click()
+        assert self.page.variable1_field_val == initial_value
+
+    def test_reset_single_to_script(self):
+        """
+        Test that changing the value of a variable field and resetting to the
+        script value, by using the inline button.
+        """
+        self.page.toggle_button.click()
+        initial_value = "test_variable_value_123"
+        self.page.variable1_field = "the new value in the field"
+        assert self.page.variable1_field_val != initial_value
+
+        self.page.variable1_field_reset_buttons.to_script.click()
+        assert self.page.variable1_field_val == initial_value
+
+    def test_toggle_data_path_button(self):
+        """
+        Test that selecting data toggle path runs script to
+        alternative between '/' and '\\'
+        """
+        self.page.toggle_data_path_button.click()
+        assert self.page.data_path_text() == "Data: \\tmp"
+        self.page.toggle_data_path_button.click()
+        assert self.page.data_path_text() == "Data: /tmp"
+
+    def test_non_existent_run(self):
+        """
+        Test that going to the run summary for a non-existent run will redirect
+        back to the runs list page and show a warning message to the user.
+        """
+        self.page = RunSummaryPage(self.driver, self.instrument_name, 12345, 0, batch_run=True)
+        self.page.launch()
+        self.driver.get(f"{self.driver.current_url}&filter=batch_runs")
+        self.page = RunsListPage(self.driver, self.instrument_name)
+
+        assert self.page.top_alert_message_text == 'Run 12345-0 does not exist. '\
+                                                   'Redirected to the instrument page.'

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_run_summary_batch.py
@@ -6,131 +6,25 @@
 # ############################################################################### #
 """Selenium tests for the runs summary page."""
 
-from django.urls import reverse
-from selenium.webdriver.support.wait import WebDriverWait
-
-from autoreduce_db.reduction_viewer.models import ReductionRun
-from autoreduce_frontend.autoreduce_webapp.templatetags.encode_b64 import encode_b64
 from autoreduce_frontend.selenium_tests.pages.run_summary_page import RunSummaryPage
 from autoreduce_frontend.selenium_tests.pages.runs_list_page import RunsListPage
-from autoreduce_frontend.selenium_tests.tests.base_tests import ConfigureNewJobsBaseTestCase, FooterTestMixin, NavbarTestMixin
+from autoreduce_frontend.selenium_tests.tests.pages.test_run_summary import TestRunSummaryPage
 
 
 # pylint:disable=no-member
-class TestRunSummaryPage(ConfigureNewJobsBaseTestCase):
+class TestBatchRunSummaryPage(TestRunSummaryPage):
     """
     Test cases for the InstrumentSummary page when the Rerun form is NOT
     visible.
     """
 
-    fixtures = ConfigureNewJobsBaseTestCase.fixtures + ["run_with_one_variable", "batch_run_with_one_variable"]
+    fixtures = TestRunSummaryPage.fixtures + ["batch_run_with_one_variable"]
 
     def setUp(self) -> None:
         """Set up RunSummaryPage before each test case."""
         super().setUp()
         self.page = RunSummaryPage(self.driver, self.instrument_name, 2, 0, batch_run=True)
         self.page.launch()
-
-    def test_reduction_job_panel_displayed(self):
-        """Test that the reduction job panel is showing the right things."""
-        # only one run in the fixture, get it for assertions
-        run = ReductionRun.objects.first()
-        assert self.page.reduction_job_panel.is_displayed()
-        assert self.page.run_description_text() == f"Run description: {run.run_description}"
-        # because it's started_by: -1, determined in `started_by_id_to_name`
-        assert self.page.started_by_text() == "Started by: Development team"
-        assert self.page.status_text() == "Status: Completed"
-        assert self.page.instrument_text() == f"Instrument: {run.instrument.name}"
-        assert self.page.rb_number_text() == f"RB Number: {run.experiment.reference_number}"
-        assert self.page.last_updated_text() == "Last Updated: 19 Oct 2020, 6:35 p.m."
-        assert self.page.data_path_text() == "Data: /tmp"
-        assert self.page.reduction_host_text() == "Host: test-host-123"
-
-    def test_reduction_job_panel_reset_to_values_first_used_for_run(self):
-        """
-        Test that the button to reset the variables to the values first used for
-        the run works.
-        """
-        self.page.toggle_button.click()
-        self.page.variable1_field = "the new value in the field"
-
-        self.page.reset_to_initial_values.click()
-
-        # need to re-query the driver because resetting replaces the elements
-        assert self.page.variable1_field.get_attribute("value") == "value1"
-
-    def test_reduction_job_panel_reset_to_current_reduce_vars(self):
-        """
-        Test that the button to reset the variables to the values from the
-        reduce_vars script works.
-        """
-        self.page.toggle_button.click()
-        self.page.variable1_field = "the new value in the field"
-
-        self.page.reset_to_current_values.click()
-
-        # need to re-query the driver because resetting replaces the elements
-        assert self.page.variable1_field.get_attribute("value") == "test_variable_value_123"
-
-    def test_rerun_form(self):
-        """
-        Test that the rerun form shows contents from Variable in database (from
-        the fixture) and not reduce_vars.py.
-        """
-        rerun_form = self.page.rerun_form
-        assert not rerun_form.is_displayed()
-        self.page.toggle_button.click()
-        assert rerun_form.is_displayed()
-        assert rerun_form.find_element_by_id(f"var-standard-{encode_b64('variable1')}").get_attribute(
-            "value") == "value1"
-        labels = rerun_form.find_elements_by_tag_name("label")
-
-        WebDriverWait(self.driver, 10).until(lambda _: labels[0].text == "Re-run description")
-        WebDriverWait(self.driver, 10).until(lambda _: labels[1].text == "variable1")
-
-    def test_back_to_instruments_goes_back(self):
-        """Test that clicking back goes back to the instrument."""
-        back = self.page.cancel_button
-        assert back.is_displayed()
-        assert back.text == f"Back to {self.instrument_name} runs"
-        back.click()
-        assert reverse("runs:list", kwargs={"instrument": self.instrument_name}) in self.driver.current_url
-
-    def test_reset_single_to_initial(self):
-        """
-        Tests changing the value of a variable field and resetting to the
-        initial value, by using the inline button.
-        """
-        self.page.toggle_button.click()
-        initial_value = self.page.variable1_field_val
-        self.page.variable1_field = "the new value in the field"
-        assert self.page.variable1_field_val != initial_value
-
-        self.page.variable1_field_reset_buttons.to_initial.click()
-        assert self.page.variable1_field_val == initial_value
-
-    def test_reset_single_to_script(self):
-        """
-        Test that changing the value of a variable field and resetting to the
-        script value, by using the inline button.
-        """
-        self.page.toggle_button.click()
-        initial_value = "test_variable_value_123"
-        self.page.variable1_field = "the new value in the field"
-        assert self.page.variable1_field_val != initial_value
-
-        self.page.variable1_field_reset_buttons.to_script.click()
-        assert self.page.variable1_field_val == initial_value
-
-    def test_toggle_data_path_button(self):
-        """
-        Test that selecting data toggle path runs script to
-        alternative between '/' and '\\'
-        """
-        self.page.toggle_data_path_button.click()
-        assert self.page.data_path_text() == "Data: \\tmp"
-        self.page.toggle_data_path_button.click()
-        assert self.page.data_path_text() == "Data: /tmp"
 
     def test_non_existent_run(self):
         """

--- a/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list.py
+++ b/autoreduce_frontend/selenium_tests/tests/pages/test_runs_list.py
@@ -52,7 +52,7 @@ class TestRunsList(BaseTestCase, AccessibilityTestMixin, FooterTestMixin, Navbar
         """
         self.page.launch()
         expected = "The buttons above have been disabled because reduce_vars.py is missing for this instrument."
-        assert self.page.alert_message_text() == expected
+        assert self.page.variables_alert_message_text() == expected
 
     def test_alert_message_when_reduce_vars_has_error(self):
         """
@@ -67,7 +67,7 @@ class TestRunsList(BaseTestCase, AccessibilityTestMixin, FooterTestMixin, Navbar
 
         self.page.launch()
         expected = "The buttons above have been disabled because reduce_vars.py has an import or syntax error."
-        assert self.page.alert_message_text() == expected
+        assert self.page.variables_alert_message_text() == expected
 
         data_archive.delete()
 

--- a/autoreduce_frontend/templates/runs_list.html
+++ b/autoreduce_frontend/templates/runs_list.html
@@ -10,6 +10,9 @@
     {% if message %}
         <div class="text-center card" id="notactive">{{ message }}</div>
     {% else %}
+        {% if info_message %}
+        <div class="text-center alert alert-warning">{{ info_message }}</div>
+        {% endif %}
         <!-- Instrument Name -->
         <div class="row">
             <div class="col-lg-12 text-center">
@@ -88,7 +91,7 @@
             <form action="{{ request.path }}" method="get" id="filter_options">
             <div class="form-row align-items-center">
                 <div class="col-auto my-1">
-                    {{ options_form.filter|as_crispy_field }} 
+                    {{ options_form.filter|as_crispy_field }}
                 </div>
                 <div class="col-auto my-1">
                     {{ options_form.per_page|as_crispy_field }}

--- a/autoreduce_frontend/templates/runs_list.html
+++ b/autoreduce_frontend/templates/runs_list.html
@@ -11,7 +11,7 @@
         <div class="text-center card" id="notactive">{{ message }}</div>
     {% else %}
         {% if info_message %}
-        <div class="text-center alert alert-warning">{{ info_message }}</div>
+        <div id="top-alert-message" class="text-center alert alert-warning">{{ info_message }}</div>
         {% endif %}
         <!-- Instrument Name -->
         <div class="row">
@@ -77,7 +77,7 @@
                 </p>
             </div>
             {% if not has_variables %}
-                <div class="alert alert-warning" role="alert" id="alert_message">
+                <div class="alert alert-warning" role="alert" id="variables_alert_message">
                     <i class="fa fa-exclamation-triangle"></i>
                     &nbsp;&nbsp;The buttons above have been disabled because {{ error_reason }}.
                 </div>


### PR DESCRIPTION
### Summary of work
Going to non-existent run number or version no longer shows an error, instead it redirects to `runs:list` and shows a warning message of what went wrong.

### How to test your work
1. Run the webapp
2. Go to http://127.0.0.1:8000/runs/INTER/64034/1000
3. You should be at the `runs:list` page of INTER and seeing a warning message saying INTER 64034-1000 doesn't exist, or something along those lines
