### PR TITLE
Adds FA next/prev chars, centers run confirmation & better variable render

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.7
 
-      - uses: ISISScientificComputing/autoreduce-actions/build@master
+      - uses: ISISScientificComputing/autoreduce-actions/build@main
         with:
           package_name: autoreduce_frontend
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: 3.7
 
-      - uses: ISISScientificComputing/autoreduce-actions/build@master
+      - uses: ISISScientificComputing/autoreduce-actions/build@main
         with:
           package_name: autoreduce_frontend
 
@@ -154,11 +154,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - uses: ISISScientificComputing/autoreduce-actions/build@master
+      - uses: ISISScientificComputing/autoreduce-actions/build@main
         with:
           package_name: autoreduce_frontend
 
-      - uses: ISISScientificComputing/autoreduce-actions/code_inspection@master
+      - uses: ISISScientificComputing/autoreduce-actions/code_inspection@main
         with:
           package_name: autoreduce_frontend
 

--- a/ansible/roles/run/webapp/start/tasks/main.yml
+++ b/ansible/roles/run/webapp/start/tasks/main.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Ensure group "docker" exists
+  ansible.builtin.group:
+    name: docker
+    state: present
+
+- name: Adding user {{ autoreduction_user }} to `docker` group to allow sudoless docker usage
+  user: name={{ autoreduction_user }}
+        group={{ autoreduction_user }}
+        shell=/bin/bash
+        password=${password}
+        groups=docker
+        append=yes
+
 - name: Set run_command depending on deployment stage
   include_vars: "{{ deployment_stage }}.yml"
 

--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -200,3 +200,5 @@ CONN_MAX_AGE = 60
 # Currently this is attached to the request when it goes through the proxy server
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 DATA_ANALYSIS_BASE_URL = "https://data.analysis.stfc.ac.uk/data/browse/#INSTRUMENT/"  # note: the trailing / is important
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/autoreduce_frontend/reduction_viewer/views/common.py
+++ b/autoreduce_frontend/reduction_viewer/views/common.py
@@ -5,6 +5,8 @@ from typing import Tuple
 from autoreduce_db.reduction_viewer.models import ReductionArguments
 from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 
+UNAUTHORIZED_MESSAGE = "User is not authorized to submit batch runs. Please contact the Autoreduce team "\
+                       "at ISISREDUCE@stfc.ac.uk to request the permissions."
 # Holds the default value used when there is no value for the variable
 # in the default variables dictionary. Stored in a parameter for re-use in tests.
 DEFAULT_WHEN_NO_VALUE = ""

--- a/autoreduce_frontend/reduction_viewer/views/common.py
+++ b/autoreduce_frontend/reduction_viewer/views/common.py
@@ -133,11 +133,17 @@ def convert_to_python_type(value: str):
 def make_reduction_arguments(post_arguments: dict, instrument: str) -> dict:
     """
     Given new variables from the POST request and the default variables from reduce_vars.py
-     create a dictionary of the new variables
-    :param post_arguments: The new variables to be created
-    :param default_variables: The default variables
-    :return: The new variables as a dict
-    :raises ValueError if any variable values exceed the allowed maximum
+    create a dictionary of the new variables
+
+    Args:
+        post_arguments: The new variables to be created
+        default_variables: The default variables
+
+    Returns:
+        The new variables as a dict
+
+    Raises:
+        ValueError if any variable values exceed the allowed maximum
     """
 
     defaults = VariableUtils.get_default_variables(instrument)

--- a/autoreduce_frontend/reduction_viewer/views/configure_new_batch_run.py
+++ b/autoreduce_frontend/reduction_viewer/views/configure_new_batch_run.py
@@ -10,7 +10,8 @@ from django.views.generic import FormView
 from django.shortcuts import render
 
 from autoreduce_frontend.utilities import input_processing
-from autoreduce_frontend.reduction_viewer.views.common import UNAUTHORIZED_MESSAGE, prepare_arguments_for_render, make_reduction_arguments
+from autoreduce_frontend.reduction_viewer.views.common import (UNAUTHORIZED_MESSAGE, prepare_arguments_for_render,
+                                                               make_reduction_arguments)
 
 UNKNOWN_ERROR_MESSAGE = "Unknown error encountered"
 RUN_EMPTY_MESSAGE = "Run field was invalid or empty"

--- a/autoreduce_frontend/reduction_viewer/views/configure_new_batch_run.py
+++ b/autoreduce_frontend/reduction_viewer/views/configure_new_batch_run.py
@@ -10,12 +10,10 @@ from django.views.generic import FormView
 from django.shortcuts import render
 
 from autoreduce_frontend.utilities import input_processing
-from autoreduce_frontend.reduction_viewer.views.common import prepare_arguments_for_render, make_reduction_arguments
+from autoreduce_frontend.reduction_viewer.views.common import UNAUTHORIZED_MESSAGE, prepare_arguments_for_render, make_reduction_arguments
 
 UNKNOWN_ERROR_MESSAGE = "Unknown error encountered"
 RUN_EMPTY_MESSAGE = "Run field was invalid or empty"
-UNAUTHORIZED_MESSAGE = "User is not authorized to submit batch runs. Please contact the Autoreduce team "\
-                       "at ISISREDUCE@stfc.ac.uk to request the permissions."
 UNABLE_TO_CONNECT_MESSAGE = "Unable to connect to the Autoreduce job submission service. If the error "\
                             "persists please let the Autoreduce team know at ISISREDUCE@stfc.ac.uk"
 

--- a/autoreduce_frontend/reduction_viewer/views/run_confirmation.py
+++ b/autoreduce_frontend/reduction_viewer/views/run_confirmation.py
@@ -17,7 +17,7 @@ from django.db.models.query import QuerySet
 from requests.exceptions import ConnectionError  # pylint:disable=redefined-builtin
 
 from autoreduce_frontend.autoreduce_webapp.view_utils import (check_permissions, login_and_uows_valid, render_with)
-from autoreduce_frontend.reduction_viewer.views.common import make_reduction_arguments
+from autoreduce_frontend.reduction_viewer.views.common import UNAUTHORIZED_MESSAGE, make_reduction_arguments
 from autoreduce_frontend.utilities import input_processing
 
 LOGGER = logging.getLogger(__package__)
@@ -91,7 +91,7 @@ def run_confirmation(request, instrument: str):
     try:
         auth_token = str(request.user.auth_token)
     except AttributeError as err:
-        context_dictionary['error'] = "User is not authorized to submit batch runs."
+        context_dictionary['error'] = UNAUTHORIZED_MESSAGE
         return context_dictionary
     # run_description gets stored in run_description in the ReductionRun object
     max_run_description_length = ReductionRun._meta.get_field('run_description').max_length

--- a/autoreduce_frontend/templates/batch_run_confirmation.html
+++ b/autoreduce_frontend/templates/batch_run_confirmation.html
@@ -23,7 +23,7 @@
         </div>
     {% else %}
         <div class="row" id="error_container">
-            <div class="col-md-8 col-md-offset-2">
+            <div class="col-md-8 offset-2">
                 <div class="alert alert-danger">
                     <div class="row">
                         <div class="col-md-12 text-center">

--- a/autoreduce_frontend/templates/run_confirmation.html
+++ b/autoreduce_frontend/templates/run_confirmation.html
@@ -8,7 +8,7 @@
 {% block body %}
     {% if runs and not error %}
         <div class="row">
-            <div class="col-md-8 col-md-offset-2">
+            <div class="col-8 offset-2">
                 <div class="card">
                     <div class="card-header">
                         <div class="card-title">
@@ -71,7 +71,7 @@
         </div>
     {% else %}
         <div class="row" id="error_container">
-            <div class="col-md-8 col-md-offset-2">
+            <div class="col-8 offset-2">
                 <div class="alert alert-danger">
                     <div class="row">
                         <div class="col-md-12 text-center">

--- a/autoreduce_frontend/templates/run_confirmation.html
+++ b/autoreduce_frontend/templates/run_confirmation.html
@@ -46,23 +46,21 @@
                             <br>
                             <div class="row col-md-12">
                             <legend>Standard Variables</legend>
+                            <div>
+                                <ul class="list-group">
                                 {% for name, value in variables.standard_vars.items %}
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <strong>{{ name }}:</strong> {{value}}
-                                    </div>
-                                </div>
+                                    <li class="list-group-item">{{ name }}: {{ value }}</li>
                                 {% endfor %}
+                                </ul>
+                            </div>
                             </div>
                             <div class="row col-md-12">
                                 <legend>Advanced Variables</legend>
+                                <ul class="list-group">
                                 {% for name, value in variables.advanced_vars.items %}
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <strong>{{ name }}:</strong> {{value}}
-                                        </div>
-                                    </div>
+                                    <li class="list-group-item">{{ name }}: {{ value }}</li>
                                 {% endfor %}
+                                </ul>
                             </div>
                         </fieldset>
                     </div>

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -206,15 +206,10 @@
 
         <div class="d-flex justify-content-center mt-4">
             <div class="text-center">
-                <a href="{% generate_run_link instrument run=newest_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if newest_run == run %} disabled {% endif %}" id="newest"> Newest {{ newest_run }}
-                </a>
-                <a href="{% generate_run_link instrument run=next_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if next_run == run %} disabled {% endif %}" id="next">« Next
-                </a>
-                <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel"
-                    >Back to {{ run.instrument.name }} runs
-                </a>
-                <a href="{% generate_run_link instrument run=previous_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if previous_run == run %} disabled {% endif %}" id="previous">Previous »
-                </a>
+                <a href="{% generate_run_link instrument run=previous_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if previous_run == run %} disabled {% endif %}" id="previous"><i class="fas fa-step-backward"></i>Previous</i></a>
+                <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel">Back to {{ run.instrument.name }} runs</a>
+                <a href="{% generate_run_link instrument run=next_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if next_run == run %} disabled {% endif %}" id="next">Next <i class="fas fa-step-forward"></i></a>
+                <a href="{% generate_run_link instrument run=newest_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if newest_run == run %} disabled {% endif %}" id="newest"> Newest {{ newest_run }}</a>
             </div>
         </div>
 

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -30,7 +30,7 @@
         </div>
         {% if plot_error_message %}
             <div class="row">
-                <div class="col-md-8 col-md-offset-2">
+                <div class="col-8 offset-2">
                     <p class="card text-center">{{ plot_error_message }}</p>
                 </div>
             </div>

--- a/autoreduce_frontend/templates/run_summary.html
+++ b/autoreduce_frontend/templates/run_summary.html
@@ -206,14 +206,14 @@
 
         <div class="d-flex justify-content-center mt-4">
             <div class="text-center">
-                <a href="{% generate_run_link instrument run=newest_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if newest_run == run %} disabled {% endif %}" id="newest">&#124;&#60; Newest
+                <a href="{% generate_run_link instrument run=newest_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if newest_run == run %} disabled {% endif %}" id="newest"> Newest {{ newest_run }}
                 </a>
-                <a href="{% generate_run_link instrument run=next_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if next_run == run %} disabled {% endif %}" id="next">&#60;&#60; Next
+                <a href="{% generate_run_link instrument run=next_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if next_run == run %} disabled {% endif %}" id="next">« Next
                 </a>
                 <a href="{% url 'runs:list' run.instrument.name %}?page={{ current_page }}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back" id="cancel"
                     >Back to {{ run.instrument.name }} runs
                 </a>
-                <a href="{% generate_run_link instrument run=previous_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if previous_run == run %} disabled {% endif %}" id="previous">Previous &#62;&#62;
+                <a href="{% generate_run_link instrument run=previous_run %}?page={{current_page}}&per_page={{ per_page }}&sort={{ page_type }}&filter={{ filtering }}" class="btn btn-primary back {% if previous_run == run %} disabled {% endif %}" id="previous">Previous »
                 </a>
             </div>
         </div>

--- a/autoreduce_frontend/templates/snippets/instrument_summary.html
+++ b/autoreduce_frontend/templates/snippets/instrument_summary.html
@@ -19,7 +19,7 @@
             </div>
         <div class="row" id="upcoming_arguments_by_run">
             <div class="col-md-12">
-        {% if upcoming_arguments_by_run %}
+                {% if upcoming_arguments_by_run %}
                     <div class="card">
                         <div class="card-header">
                             <div class="card-title">Upcoming Arguments</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 axe-selenium-python==2.1.6
 django-debug-toolbar==3.2.2
-autoreduce-rest-api==22.0.0.dev12
+autoreduce-rest-api
 gunicorn
 mysqlclient==2.0.3
 selenium==3.141.0


### PR DESCRIPTION
### Summary of work
Adds FA next/prev chars - instead of using plaintext <, >, it now uses the FontAwesome ones in `run_summary.html`. The newest run now shows the run number instead of any symbol.

Centers run confirmation form, and uses a bootstrap for a better variable look

### How to test your work
1. Start the webapp, rest api, ActiveMQ container and queue listener
2. Go to a run's summary - here the changes to next/previous/newest should be visible
3. Submit a rerun and check that the form in run confirmation page is centered and that the variables are rendered the same way as in the instrument summary page.

### Bugs
- Variables with long values don't overflow and get out of the box

Fixes AR-1580
Fixes AR-1585
Fixes AR-1586